### PR TITLE
extract unops to temporaries

### DIFF
--- a/source/HaxeExpr.hx
+++ b/source/HaxeExpr.hx
@@ -2,12 +2,31 @@ package;
 
 import haxe.macro.Expr;
 
+enum abstract HaxeExprFlags(Int) from Int to Int {
+    public var Processed = 1;
+}
+
 @:structInit
 class HaxeExpr {
 	public var remapTo:Null<String> = null;
 	public var specialDef:SpecialExprDef;
+	public var parent:HaxeExpr = null;
+	public var parentIdx:Int = 0;
+	public var flags:HaxeExprFlags = 0;
 	public var def:HaxeExprDef;
 	public var t:String;
+
+	public function copy(deep: Bool = false): HaxeExpr {
+	    return {
+			remapTo: remapTo,
+			specialDef: specialDef,
+			parent: deep ? parent.copy() : parent,
+			parentIdx: parentIdx,
+			flags: flags,
+			def: def,
+			t: t
+		};
+	}
 
 	public function toString(): String {
 		return Std.string(def);
@@ -197,7 +216,7 @@ class HaxeTypeDefinition {
         if (goImports.contains(imp)) {
             return;
         }
-        
+
         goImports.push(imp);
     }
 	public var name:String;

--- a/source/Module.hx
+++ b/source/Module.hx
@@ -42,7 +42,7 @@ class Module {
 
     public function resolveClass(pack:Array<String>, name:String):HaxeTypeDefinition {
         var resolveModule = pack.join(".") + (pack.length > 0 ? "." : "") + name;
-        trace(resolveModule);
+        // trace(resolveModule);
         // local
         if (pack.length == 0) {
             return resolveLocalDef(this, name);

--- a/source/parser/dump/ExprParser.hx
+++ b/source/parser/dump/ExprParser.hx
@@ -116,7 +116,7 @@ class ExprParser {
                     case "String":
                         final len = s.length - 1;
                         // space + "", end ""
-                        EConst(CString(s.substring(2, len)));
+                        EConst(CString(s.substring(1, len)));
                     case "Int":
                         EConst(CInt(s));
                     case "Float":
@@ -261,7 +261,11 @@ class ExprParser {
         if (lineIndex >= lines.length)
             return null;
         // get the starting [ character
-        final objectStartIndex = line.indexOf("[", stringIndex) + 1;
+        final quoteIndex = line.indexOf('"', stringIndex) + 1;
+        var objectStartIndex = line.indexOf("[", stringIndex) + 1;
+        // check if const string is quote
+        if (quoteIndex != 0 && objectStartIndex > quoteIndex)
+            objectStartIndex = 0;
         // not -1, because we are adding ObjectStartIndex
         // in order to skip over the char (. = cursor)
         // before: .[

--- a/source/parser/dump/ExprParser.hx
+++ b/source/parser/dump/ExprParser.hx
@@ -247,11 +247,11 @@ class ExprParser {
     function printObject(object:Object, depth:Int=0) {
         final tab = [for (i in 0...depth * 4) " "].join("");
         final objectStr = "(" + object.string() + ")";
-        trace(tab + object.def + "[" + object.defType + " " + object.subType + "]");
+        // trace(tab + object.def + "[" + object.defType + " " + object.subType + "]");
         if (object.def == STRING)
-            trace(tab + "    " + object.string());
+            // trace(tab + "    " + object.string());
         for (subObject in object.objects) {
-            printObject(subObject, depth + 1);
+            // printObject(subObject, depth + 1);
         }
     }
 

--- a/source/parser/dump/RecordTools.hx
+++ b/source/parser/dump/RecordTools.hx
@@ -12,7 +12,7 @@ import parser.dump.RecordParser;
 import HaxeExpr;
 /**
  * Where RecordEntry is turned into a HaxeTypeDefinition
- * @param record 
+ * @param record
  * @return HaxeTypeDefinition
  */
 function recordToHaxeTypeDefinition(record: RecordEntry):HaxeTypeDefinition {
@@ -20,7 +20,7 @@ function recordToHaxeTypeDefinition(record: RecordEntry):HaxeTypeDefinition {
         trace("cl_module should never be null: " + record.record_debug_path);
         return null;
     }
-    
+
     var kind:HaxeTypeDefinitionKind = TDClass;
     var fields:Array<HaxeField> = [];
 
@@ -50,8 +50,7 @@ function recordToHaxeTypeDefinition(record: RecordEntry):HaxeTypeDefinition {
         case REnum:
             var t = record.toEnum();
         case RUnknown:
-            trace(record.record_debug_path);
-            trace('record_kind should not be unknown: ' + record.module);
+            trace('record_kind should not be unknown: ' + record.module + ' in ' + record.record_debug_path);
     }
     return {
         name: record.path,

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -32,6 +32,8 @@ class Transformer {
                 FieldAccess.transformFieldAccess(this, e);
             case EUnop(op, postFix, e1):
                 UnopExpr.transformUnop(this, e, op, postFix, e1);
+            case EWhile(cond, body, norm):
+                While.transformWhile(this, e, cond, body, norm);
             default:
                 var idx = 0;
                 HaxeExprTools.iter(e, (le) -> {

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -34,6 +34,8 @@ class Transformer {
                 UnopExpr.transformUnop(this, e, op, postFix, e1);
             case EWhile(cond, body, norm):
                 While.transformWhile(this, e, cond, body, norm);
+            case EIf(cond, branchTrue, branchFalse):
+                If.transformIf(this, e, cond, branchTrue, branchFalse);
             default:
                 var idx = 0;
                 HaxeExprTools.iter(e, (le) -> {
@@ -134,5 +136,15 @@ class Transformer {
         }
 
         return expr;
+    }
+    public function ensureBlock(e:HaxeExpr):HaxeExpr {
+        if (e == null) {
+            return null;
+        }
+
+        return switch (e.def) {
+            case EBlock(_): e;
+            case _: { t: null, specialDef: null, def: EBlock([e])}
+        }
     }
 }

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -37,13 +37,15 @@ class Transformer {
             case EIf(cond, branchTrue, branchFalse):
                 If.transformIf(this, e, cond, branchTrue, branchFalse);
             default:
-                var idx = 0;
-                HaxeExprTools.iter(e, (le) -> {
-                    transformExpr(le, e, idx);
-                    idx++;
-                });
-
+                iterateExpr(e);
         }
+    }
+    public function iterateExpr(e:HaxeExpr) {
+        var idx = 0;
+        HaxeExprTools.iter(e, (le) -> {
+            transformExpr(le, e, idx);
+            idx++;
+        });
     }
     public function transformDef(def:HaxeTypeDefinition) {
         if (def.fields == null)
@@ -144,7 +146,7 @@ class Transformer {
 
         return switch (e.def) {
             case EBlock(_): e;
-            case _: { t: null, specialDef: null, def: EBlock([e])}
+            case _: { t: null, specialDef: null, def: EBlock([e]) };
         }
     }
 }

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -15,9 +15,14 @@ import transformer.exprs.*;
 class Transformer {
     public var module:Module = null;
     public var def:HaxeTypeDefinition = null;
-    public function transformExpr(e:HaxeExpr) {
+    public var tempId:Int = 0;
+    public function transformExpr(e:HaxeExpr, ?parent:HaxeExpr, ?parentIdx:Int) {
         if (e == null || e.def == null)
             return;
+        if (parent != null)
+            e.parent = parent;
+            e.parentIdx = parentIdx;
+
         switch e.def {
             case EConst(c):
                 Const.transformConst(this, e);
@@ -25,8 +30,15 @@ class Transformer {
                 Try.transformTry(this, e);
             case EField(_, _, _):
                 FieldAccess.transformFieldAccess(this, e);
+            case EUnop(op, postFix, e1):
+                UnopExpr.transformUnop(this, e, op, postFix, e1);
             default:
-                HaxeExprTools.iter(e, transformExpr);
+                var idx = 0;
+                HaxeExprTools.iter(e, (le) -> {
+                    transformExpr(le, e, idx);
+                    idx++;
+                });
+
         }
     }
     public function transformDef(def:HaxeTypeDefinition) {
@@ -46,5 +58,79 @@ class Transformer {
             if (field.expr != null)
                 transformExpr(field.expr);
         }
+    }
+    public function findOuterBlock(e:HaxeExpr): { pos: Int, of: Null<HaxeExpr> } {
+        var parent: HaxeExpr = e;
+        var pos: Int = 0;
+
+        while (parent != null) {
+            switch (parent?.def) {
+                case EBlock(_): break;
+                case _:
+                    pos = parent.parentIdx;
+                    parent = parent.parent;
+            }
+        }
+
+        return { pos: pos, of: parent };
+    }
+    public function createTemporary(e:HaxeExpr, ?pre:HaxeExpr, ?post: HaxeExpr): HaxeExpr {
+        var expr: HaxeExpr = {
+            t: null,
+            specialDef: null,
+            def: EConst(CIdent("#FAILED_TEMP"))
+        };
+
+        var block = findOuterBlock(e);
+        if (block.of == null) {
+            trace('could not create temporary: no outer block');
+            return expr;
+        }
+
+        var children: Array<HaxeExpr> = switch (block.of.def) {
+            case EBlock(x): x;
+            case _: null;
+        }
+
+        if (children == null) {
+            trace('could not create temporary: children should not be null');
+            return expr;
+        }
+
+        var id = tempId++;
+        expr.def = EConst(CIdent('_temp_$id'));
+
+        var insertPos = block.pos;
+        var insertCount = 0;
+
+        if (pre != null) {
+            children.insert(insertPos, pre);
+            insertPos++;
+            insertCount++;
+        }
+
+        children.insert(insertPos, {
+            t: null,
+            specialDef: null,
+            def: EVars([
+                { name: '_temp_$id', expr: e }
+            ])
+        });
+
+        insertPos++;
+        insertCount++;
+
+        if (post != null) {
+            children.insert(insertPos, post);
+            insertCount++;
+        }
+
+        for (i in (block.pos + insertCount)...children.length) {
+            if (children[i].parentIdx >= block.pos) {
+                children[i].parentIdx += insertCount;
+            }
+        }
+
+        return expr;
     }
 }

--- a/source/transformer/exprs/FieldAccess.hx
+++ b/source/transformer/exprs/FieldAccess.hx
@@ -2,21 +2,25 @@ package transformer.exprs;
 
 import HaxeExpr;
 import transformer.Transformer;
+import translator.TranslatorTools;
 
 function transformFieldAccess(t:Transformer, e:HaxeExpr) {
     switch e.def {
         case EField(e2, field, kind):
-            resolveExpr(t, e2);
-            field = field.charAt(0).toUpperCase() + field.substr(1);
+            var isNative = resolveExpr(t, e2);
+            field = isNative ? field : toPascalCase(field); // field.charAt(0).toUpperCase() + field.substr(1);
             e.def = EField(e2, field, kind);
         default:
     }
 }
 
-function resolveExpr(t:Transformer, e2:HaxeExpr) {
+function resolveExpr(t:Transformer, e2:HaxeExpr): Bool {
     // TODO check go.native on $field
     final ct = HaxeExprTools.stringToComplexType(e2.t);
     var renamedIdent = "";
+    var topLevel = false;
+    var isNative = false;
+
     switch ct {
         case TPath(p):
             if (p.name == "Class" && p.pack.length == 0)
@@ -29,9 +33,16 @@ function resolveExpr(t:Transformer, e2:HaxeExpr) {
                                 case ":go.package":
                                     // import
                                     t.def.addGoImport(exprToString(meta.params[0]));
+                                    isNative = true;
                                 case ":go.native":
                                     // rename
                                     renamedIdent = exprToString(meta.params[0]);
+                                    isNative = true;
+                                case ":go.toplevel":
+                                    // used for T() calls, removes "$a." in "$a.$b"
+                                    renamedIdent = "";
+                                    topLevel = true;
+                                    isNative = true;
                                 }
                             }
                         }
@@ -39,8 +50,11 @@ function resolveExpr(t:Transformer, e2:HaxeExpr) {
                 }
         default:
     }
-    if (renamedIdent != "")
+
+    if (renamedIdent != "" || topLevel)
         e2.remapTo = renamedIdent;
+
+    return isNative; // TODO: check if class is extern
 }
 
 function exprToString(e:haxe.macro.Expr):String {

--- a/source/transformer/exprs/FieldAccess.hx
+++ b/source/transformer/exprs/FieldAccess.hx
@@ -8,7 +8,7 @@ function transformFieldAccess(t:Transformer, e:HaxeExpr) {
     switch e.def {
         case EField(e2, field, kind):
             var isNative = resolveExpr(t, e2);
-            field = isNative ? field : toPascalCase(field); // field.charAt(0).toUpperCase() + field.substr(1);
+            field = isNative ? field : toPascalCase(field); // TODO: should use field's @:go.native
             e.def = EField(e2, field, kind);
         default:
     }

--- a/source/transformer/exprs/If.hx
+++ b/source/transformer/exprs/If.hx
@@ -1,0 +1,8 @@
+package transformer.exprs;
+
+import HaxeExpr;
+import transformer.Transformer;
+
+function transformIf(t:Transformer, e:HaxeExpr, cond:HaxeExpr, branchTrue:HaxeExpr, branchFalse:HaxeExpr) {
+    e.def = EIf(cond, t.ensureBlock(branchTrue), t.ensureBlock(branchFalse));
+}

--- a/source/transformer/exprs/If.hx
+++ b/source/transformer/exprs/If.hx
@@ -5,4 +5,5 @@ import transformer.Transformer;
 
 function transformIf(t:Transformer, e:HaxeExpr, cond:HaxeExpr, branchTrue:HaxeExpr, branchFalse:HaxeExpr) {
     e.def = EIf(cond, t.ensureBlock(branchTrue), t.ensureBlock(branchFalse));
+    t.iterateExpr(e);
 }

--- a/source/transformer/exprs/UnopExpr.hx
+++ b/source/transformer/exprs/UnopExpr.hx
@@ -14,9 +14,11 @@ function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1:
     }
 
     // ignore if parent is a block
+    var inBlock = false;
     if (e0.parent != null) {
         switch (e0.parent.def) {
-            case EBlock(_): return;
+            case EBlock(_) if (postFix): return;
+            case EBlock(_): inBlock = true;
             case _: null;
         }
     }
@@ -41,8 +43,9 @@ function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1:
     var e3: HaxeExpr = { t: null, specialDef: null, def: EBinop(OpAssignOp(binop), e1, one) };
 
     // extract to temporary
-    var tmp = t.createTemporary(postFix ? e1 : e2, null, e3);
-
-    // we replace the UnOp with the proper identifier
-    e0.def = tmp.def;
+    if (inBlock) e0.def = e3.def;
+    else {
+        var tmp = t.createTemporary(postFix ? e1 : e2, null, e3);
+        e0.def = tmp.def;
+    }
 }

--- a/source/transformer/exprs/UnopExpr.hx
+++ b/source/transformer/exprs/UnopExpr.hx
@@ -1,0 +1,37 @@
+package transformer.exprs;
+
+import HaxeExpr;
+import transformer.Transformer;
+import haxe.macro.Expr;
+
+function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1: HaxeExpr) {
+    // ignore if not OpIncrement or OpDecrement
+    if (op != OpIncrement && op != OpDecrement) {
+        return;
+    }
+
+    // we first copy over some information needed for temporaries
+    e1.parent = e0.parent;
+    e1.parentIdx = e0.parentIdx;
+
+    // convert Unop to Binop
+    var binop: Binop = switch(op) {
+        case OpIncrement: OpAdd;
+        case OpDecrement: OpSub;
+        case _: {
+            trace('invalid unop to binop');
+            null;
+        }
+    }
+
+    // create the required expressions
+    var one: HaxeExpr = { t: null, specialDef: null, def: EConst(CInt('1')) };
+    var e2: HaxeExpr = { t: null, specialDef: null, def: EBinop(binop, e1, one), parent: e0.parent, parentIdx: e0.parentIdx };
+    var e3: HaxeExpr = { t: null, specialDef: null, def: EBinop(OpAssignOp(binop), e1, one) };
+
+    // extract to temporary
+    var tmp = t.createTemporary(postFix ? e1 : e2, null, e3);
+
+    // we replace the UnOp with the proper identifier
+    e0.def = tmp.def;
+}

--- a/source/transformer/exprs/UnopExpr.hx
+++ b/source/transformer/exprs/UnopExpr.hx
@@ -4,9 +4,9 @@ import HaxeExpr;
 import transformer.Transformer;
 import haxe.macro.Expr;
 
-function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1: HaxeExpr) {
+function transformUnop(t:Transformer, e: HaxeExpr, op: Unop, postFix: Bool, e1: HaxeExpr) {
     // iterate over unop
-    t.iterateExpr(e0);
+    t.iterateExpr(e);
 
     // ignore if not OpIncrement or OpDecrement
     if (op != OpIncrement && op != OpDecrement) {
@@ -15,8 +15,8 @@ function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1:
 
     // ignore if parent is a block
     var inBlock = false;
-    if (e0.parent != null) {
-        switch (e0.parent.def) {
+    if (e.parent != null) {
+        switch (e.parent.def) {
             case EBlock(_) if (postFix): return;
             case EBlock(_): inBlock = true;
             case _: null;
@@ -24,8 +24,8 @@ function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1:
     }
 
     // we first copy over some information needed for temporaries
-    e1.parent = e0.parent;
-    e1.parentIdx = e0.parentIdx;
+    e1.parent = e.parent;
+    e1.parentIdx = e.parentIdx;
 
     // convert Unop to Binop
     var binop: Binop = switch(op) {
@@ -39,13 +39,13 @@ function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1:
 
     // create the required expressions
     var one: HaxeExpr = { t: null, specialDef: null, def: EConst(CInt('1')) };
-    var e2: HaxeExpr = { t: null, specialDef: null, def: EBinop(binop, e1, one), parent: e0.parent, parentIdx: e0.parentIdx };
+    var e2: HaxeExpr = { t: null, specialDef: null, def: EBinop(binop, e1, one), parent: e.parent, parentIdx: e.parentIdx };
     var e3: HaxeExpr = { t: null, specialDef: null, def: EBinop(OpAssignOp(binop), e1, one) };
 
     // extract to temporary
-    if (inBlock) e0.def = e3.def;
+    if (inBlock) e.def = e3.def;
     else {
         var tmp = t.createTemporary(postFix ? e1 : e2, null, e3);
-        e0.def = tmp.def;
+        e.def = tmp.def;
     }
 }

--- a/source/transformer/exprs/UnopExpr.hx
+++ b/source/transformer/exprs/UnopExpr.hx
@@ -10,6 +10,14 @@ function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1:
         return;
     }
 
+    // ignore if parent is a block
+    if (e0.parent != null) {
+        switch (e0.parent.def) {
+            case EBlock(_): return;
+            case _: null;
+        }
+    }
+
     // we first copy over some information needed for temporaries
     e1.parent = e0.parent;
     e1.parentIdx = e0.parentIdx;

--- a/source/transformer/exprs/UnopExpr.hx
+++ b/source/transformer/exprs/UnopExpr.hx
@@ -5,6 +5,9 @@ import transformer.Transformer;
 import haxe.macro.Expr;
 
 function transformUnop(t:Transformer, e0: HaxeExpr, op: Unop, postFix: Bool, e1: HaxeExpr) {
+    // iterate over unop
+    t.iterateExpr(e0);
+
     // ignore if not OpIncrement or OpDecrement
     if (op != OpIncrement && op != OpDecrement) {
         return;

--- a/source/transformer/exprs/While.hx
+++ b/source/transformer/exprs/While.hx
@@ -1,0 +1,11 @@
+package transformer.exprs;
+
+import HaxeExpr;
+import transformer.Transformer;
+
+function transformWhile(t:Transformer, e:HaxeExpr, cond:HaxeExpr, body:HaxeExpr, norm:Bool) {
+    e.def = EWhile(cond, switch (body.def) {
+        case EBlock(_): body;
+        case _: { t: null, specialDef: null, def: EBlock([ body ]) };
+    }, norm);
+}

--- a/source/transformer/exprs/While.hx
+++ b/source/transformer/exprs/While.hx
@@ -5,4 +5,5 @@ import transformer.Transformer;
 
 function transformWhile(t:Transformer, e:HaxeExpr, cond:HaxeExpr, body:HaxeExpr, norm:Bool) {
     e.def = EWhile(cond, t.ensureBlock(body), norm);
+    t.iterateExpr(e);
 }

--- a/source/transformer/exprs/While.hx
+++ b/source/transformer/exprs/While.hx
@@ -4,8 +4,5 @@ import HaxeExpr;
 import transformer.Transformer;
 
 function transformWhile(t:Transformer, e:HaxeExpr, cond:HaxeExpr, body:HaxeExpr, norm:Bool) {
-    e.def = EWhile(cond, switch (body.def) {
-        case EBlock(_): body;
-        case _: { t: null, specialDef: null, def: EBlock([ body ]) };
-    }, norm);
+    e.def = EWhile(cond, t.ensureBlock(body), norm);
 }

--- a/source/translator/exprs/FieldAccess.hx
+++ b/source/translator/exprs/FieldAccess.hx
@@ -6,5 +6,6 @@ import HaxeExpr;
 
 function translateFieldAccess(t:Translator, e:HaxeExpr, field:String, kind:EFieldKind) {
     // TODO implement kind Safe
-    return (e.remapTo ?? t.translateExpr(e)) + '.$field';
+    var fieldOn = e.remapTo ?? t.translateExpr(e);
+    return fieldOn + (fieldOn != "" ? '.' : '') + '$field';
 }

--- a/source/translator/exprs/If.hx
+++ b/source/translator/exprs/If.hx
@@ -4,27 +4,10 @@ import translator.Translator;
 import HaxeExpr;
 
 function translateIf(t:Translator, econd:HaxeExpr, eif:HaxeExpr, eelse:HaxeExpr) {
-    final s = "if " + t.translateExpr(econd) + " " + t.translateExpr(translateToBlock(eif));
+    final s = "if " + t.translateExpr(econd) + " " + t.translateExpr(eif);
     if (eelse != null) {
-        return s + " else " + t.translateExpr(translateToBlock(eelse));
+        return s + " else " + t.translateExpr(eelse);
     }else{
         return s;
     }
-}
-
-private function translateToBlock(expr:HaxeExpr):HaxeExpr {
-    if (expr.def == null)
-        return expr;
-    switch expr.def {
-        case EIf(_, _, _):
-        case EBlock(_):
-        default:
-            return {
-                t: expr.t,
-                specialDef: null,
-                def: EBlock([expr]),
-                remapTo: expr.remapTo,
-            };
-    }
-    return expr;
 }

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -23,19 +23,22 @@ extern class Fmt {
 @:analyzer(ignore)
 class Test {
     public static function main() {
-        var n = 10;
-        var a = 0;
-        var b = 1;
-        var next = b;
-        var count = 1;
+        //var n = 10;
+        //var a = 0;
+        //var b = 1;
+        //var next = b;
+        //var count = 1;
 
-        do {
-            Fmt.println(next);
-            count++;
-            a = b;
-            b = next;
-            next = a + b;
-        } while (count <= n);
+        //do {
+        //    Fmt.println(next);
+        //    var newC = count++;
+        //    a = b;
+        //    b = next;
+        //    next = a + b;
+        //} while (count <= n);
+
+        var x = 0;
+        while (x < 20) x++;
 
         //var x = 0;
         //Fmt.println(x++);

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,28 +1,122 @@
+@:coreType @:notNull @:runtimeValue abstract Single to Float from Float {}
+
 // NOTE: @:native causes the name to change in the dump file
 // We only want to use the metadata to point to the Go reference api
 @:go.package("fmt")
 @:go.native("fmt")
 extern class Fmt {
     @:go.native("Println")
-	public static function println(e:haxe.Rest<Dynamic>):Void;
+	public static extern function Println(e:haxe.Rest<Dynamic>):Void;
 }
 
-// transformer -> goImports: ['fmt'] addModule(name: String): Void;
-// translation -> goImports Fmt.println(...) -> fmt.Println(...)
-// import "fmt"
-//
-// func main() {
-//    fmt.Println("Hello");
-// }
+@:go.toplevel
+extern class Convert {
+    @:go.native("int32")
+    public static extern function int32(x: Float): Int;
 
-// Types
-// cache = []
-//
-// go.Fmt
+    @:go.native("float32")
+    public static extern function float32(x: Float): Single;
+}
+
+@:go.package("image/color")
+@:go.native("color") // TODO: what would be best here?
+extern class RGBA {}
+
+@:go.package("github.com/gen2brain/raylib-go/raylib")
+@:go.native("rl")
+extern class Raylib {
+    public static extern var White: RGBA;  // maps to rl.White
+    public static extern var Black: RGBA; // maps to rl.Black
+    public static extern var Lime: RGBA; // maps to rl.Black
+    public static extern var DarkGreen: RGBA; // maps to rl.Black
+
+    @:go.native("InitWindow") // could be removed if function name was "InitWindow"
+    public static extern function InitWindow(width: Int, height: Int, title: String): Void;
+
+    @:go.native("SetTargetFPS")
+    public static extern function SetTargetFps(fps: Int): Void;
+
+    @:go.native("WindowShouldClose")
+    public static extern function WindowShouldClose(): Bool;
+
+    @:go.native("BeginDrawing")
+    public static extern function BeginDrawing(): Void;
+
+    @:go.native("EndDrawing")
+    public static extern function EndDrawing(): Void;
+
+    @:go.native("ClearBackground")
+    public static extern function ClearBackground(colour: RGBA): Void;
+
+    @:go.native("DrawText")
+    public static extern function DrawText(str: String, x: Int, y: Int, size: Int, colour: RGBA): Void;
+
+    @:go.native("DrawCircle")
+    public static extern function DrawCircle(x: Int, y: Int, radius: Float, colour: RGBA): Void;
+
+    @:go.native("CloseWindow")
+    public static extern function CloseWindow(): Void;
+
+    @:go.native("GetMouseX")
+    public static extern function GetMouseX(): Int;
+
+    @:go.native("GetMouseY")
+    public static extern function GetMouseY(): Int;
+
+    @:go.native("GetFrameTime")
+    public static extern function GetFrameTime(): Float;
+}
+
 @:dce(ignore)
 @:analyzer(ignore)
 class Test {
     public static function main() {
+        Raylib.InitWindow(800, 400, "raylib [core] example - basic window");
+
+        var target_x = Convert.float32(0.0);
+        var target_y = Convert.float32(0.0);
+        var vel_x = Convert.float32(0.0);
+        var vel_y = Convert.float32(0.0);
+        var current_x = Convert.float32(0.0);
+        var current_y = Convert.float32(0.0);
+
+        final stiffness = Convert.float32(10.0);
+        final damping = Convert.float32(2.0);
+
+        while (!Raylib.WindowShouldClose()) {
+            target_x = Convert.float32(Raylib.GetMouseX());
+            target_y = Convert.float32(Raylib.GetMouseY());
+
+            var dx = current_x - target_x;
+            var dy = current_y - target_y;
+
+            var fx = -stiffness * dx;
+            var fy = -stiffness * dy;
+
+            var dmx = -damping * vel_x;
+            var dmy = -damping * vel_y;
+
+            var ax = fx + dmx;
+            var ay = fy + dmy;
+
+            var dt = Raylib.GetFrameTime();
+            vel_x += ax * dt;
+            vel_y += ay * dt;
+
+            current_x += vel_x * dt;
+            current_y += vel_y * dt;
+
+            Raylib.BeginDrawing();
+            Raylib.ClearBackground(Raylib.White);
+
+            Raylib.DrawCircle(Convert.int32(target_x), Convert.int32(target_y), 20.0, Raylib.DarkGreen);
+            Raylib.DrawCircle(Convert.int32(current_x), Convert.int32(current_y), 15.0, Raylib.Lime);
+
+            Raylib.EndDrawing();
+        }
+
+        Raylib.CloseWindow();
+
         //var n = 10;
         //var a = 0;
         //var b = 1;
@@ -37,9 +131,9 @@ class Test {
         //    next = a + b;
         //} while (count <= n);
 
-        var x = 0;
-        var y = 0;
-        if (x > 5) y = x++;
+        //var x = 0;
+        //var y = 0;
+        //if (x > 5) y = x++;
 
         //var x = 0;
         //Fmt.println(x++);

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -23,19 +23,23 @@ extern class Fmt {
 @:analyzer(ignore)
 class Test {
     public static function main() {
-        var n = 10;
-        var a = 0;
-        var b = 1;
-        var next = b;
-        var count = 1;
+        //var n = 10;
+        //var a = 0;
+        //var b = 1;
+        //var next = b;
+        //var count = 1;
 
-        do {
-            Fmt.println(next);
-            count++;
-            a = b;
-            b = next;
-            next = a + b;
-        } while (count <= n);
+        //do {
+        //    Fmt.println(next);
+        //    count++;
+        //    a = b;
+        //    b = next;
+        //    next = a + b;
+        //} while (count <= n);
+
+        var x = 0;
+        Fmt.println(x++);
+        Fmt.println(++x);
 
         //var x = 10, y = 12;
         //x = 15;

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -23,23 +23,23 @@ extern class Fmt {
 @:analyzer(ignore)
 class Test {
     public static function main() {
-        //var n = 10;
-        //var a = 0;
-        //var b = 1;
-        //var next = b;
-        //var count = 1;
+        var n = 10;
+        var a = 0;
+        var b = 1;
+        var next = b;
+        var count = 1;
 
-        //do {
-        //    Fmt.println(next);
-        //    count++;
-        //    a = b;
-        //    b = next;
-        //    next = a + b;
-        //} while (count <= n);
+        do {
+            Fmt.println(next);
+            count++;
+            a = b;
+            b = next;
+            next = a + b;
+        } while (count <= n);
 
-        var x = 0;
-        Fmt.println(x++);
-        Fmt.println(++x);
+        //var x = 0;
+        //Fmt.println(x++);
+        //Fmt.println(++x);
 
         //var x = 10, y = 12;
         //x = 15;

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -38,7 +38,7 @@ class Test {
         //} while (count <= n);
 
         var x = 0;
-        while (x < 20) x++;
+        if (x > 5) x++;
 
         //var x = 0;
         //Fmt.println(x++);

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -38,7 +38,8 @@ class Test {
         //} while (count <= n);
 
         var x = 0;
-        if (x > 5) x++;
+        var y = 0;
+        if (x > 5) y = x++;
 
         //var x = 0;
         //Fmt.println(x++);


### PR DESCRIPTION
The changes in this PR tracks AST parents which allows hx2go to extract certain statements which are expressions in Haxe to temporaries. This has been used for the unop and it seems to work really well after some basic testing. 

We still need to test more complex cases and I think it would be good to add some unit tests for this one. I will not merge this PR myself as I think a review from shadow and/or elliot would be good here.