### PR TITLE
Cast basic types explicitly for binops

### DIFF
--- a/compile.hxml
+++ b/compile.hxml
@@ -1,7 +1,7 @@
 -cp source
 -m Main
 # haxelib git hxparse https://github.com/Simn/hxparse
-# haxelib git haxeparser https://github.com/vshaxe/haxe-hxparser/
+# haxelib git haxeparser https://github.com/HaxeCheckstyle/haxeparser
 -lib hxparse
 -lib haxeparser
 --dce full

--- a/go/Float32.hx
+++ b/go/Float32.hx
@@ -1,7 +1,3 @@
 package go;
 
-@:coreType @:notNull @:runtimeValue abstract Float32 from Float to Float {
-    @:op(A + B)
-    static inline function add(a:Float32, b:Float)
-        return (a:Float) + b;
-}
+@:coreType @:notNull @:runtimeValue abstract Float32 from Float to Float {}

--- a/source/Module.hx
+++ b/source/Module.hx
@@ -18,13 +18,23 @@ class Module {
     public function resolveLocalDef(module:Module, name:String) {
         for (def in module.defs) {
                 switch def.kind {
-                    case TDClass:
-                        if (def.name == name)
-                            return def;
-                    case _:
+                case TDClass:
+                    if (def.name == name)
+                        return def;
+                default:
             }
         }
-
+        switch name {
+            case "String":
+                final module = context.getModule("String");
+                return resolveGlobalDef(module, name);
+            case "Float", "Int", "Single", "Bool":
+                // StdTypes is module
+                // global
+                final module = context.getModule("StdTypes");
+                return resolveGlobalDef(module, name);
+            default:
+        }
         trace("not resolving def: " + name);
         return null;
     }

--- a/source/transformer/exprs/BinopExpr.hx
+++ b/source/transformer/exprs/BinopExpr.hx
@@ -1,0 +1,17 @@
+package transformer.exprs;
+
+import haxe.macro.Expr.Binop;
+
+function transformBinop(t:Transformer, e:HaxeExpr, op:Binop, e1:HaxeExpr, e2:HaxeExpr) {
+    if (e.t == null)
+        return;
+    switch op {
+        // Do not do a type conversion transform if assign, on lhs
+        case OpAssignOp(_):
+        case OpAssign:
+        default:
+            t.transformTypeConversion(e.t, e1);
+    }
+    t.transformTypeConversion(e.t, e2);
+    t.iterateExpr(e);
+}

--- a/source/transformer/exprs/VarDeclarations.hx
+++ b/source/transformer/exprs/VarDeclarations.hx
@@ -6,7 +6,7 @@ function transformVarDeclarations(t:Transformer, e:HaxeExpr, vars:Array<HaxeVar>
     for (i in 0...vars.length) {
         vars[i].expr.parent = e;
         vars[i].expr.parentIdx = i;
-        t.transformComplexType(t, vars[i].type);
+        t.transformComplexType(vars[i].type);
         t.transformExpr(vars[i].expr);
     }
 }

--- a/source/translator/Translator.hx
+++ b/source/translator/Translator.hx
@@ -48,6 +48,8 @@ class Translator {
                     UnopExpr.translateUnop(this, op, postFix, e);
                 case EWhile(econd, e, normalWhile):
                     While.translateWhile(this, econd, e, normalWhile);
+                case ECheckType(e2, t):
+                    CheckType.translateCheckType(this, e2, t);
                 default:
                     "_ = 0";
             }

--- a/source/translator/exprs/CheckType.hx
+++ b/source/translator/exprs/CheckType.hx
@@ -4,6 +4,7 @@ import translator.Translator;
 import HaxeExpr;
 import haxe.macro.Expr.ComplexType;
 
-function translateCheckType(t:Translator, e:HaxeExpr, t:ComplexType) {
-
+function translateCheckType(t:Translator, e:HaxeExpr, ct:ComplexType) {
+    //return t.translateExpr(e);
+    return t.translateComplexType(ct) + "(" + t.translateExpr(e) + ")";
 } 

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,21 +1,11 @@
-@:coreType @:notNull @:runtimeValue abstract Single to Float from Float {}
-
 // NOTE: @:native causes the name to change in the dump file
 // We only want to use the metadata to point to the Go reference api
+import go.Convert;
 @:go.package("fmt")
 @:go.native("fmt")
 extern class Fmt {
     @:go.native("Println")
 	public static extern function Println(e:haxe.Rest<Dynamic>):Void;
-}
-
-@:go.toplevel
-extern class Convert {
-    @:go.native("int32")
-    public static extern function int32(x: Float): Int;
-
-    @:go.native("float32")
-    public static extern function float32(x: Float): Single;
 }
 
 @:go.package("image/color")
@@ -29,6 +19,7 @@ extern class Raylib {
     public static extern var Black: RGBA; // maps to rl.Black
     public static extern var Lime: RGBA; // maps to rl.Black
     public static extern var DarkGreen: RGBA; // maps to rl.Black
+    public static extern var Red: RGBA;
 
     @:go.native("InitWindow") // could be removed if function name was "InitWindow"
     public static extern function InitWindow(width: Int, height: Int, title: String): Void;
@@ -64,7 +55,7 @@ extern class Raylib {
     public static extern function GetMouseY(): Int;
 
     @:go.native("GetFrameTime")
-    public static extern function GetFrameTime(): Float;
+    public static extern function GetFrameTime(): go.Float32;
 }
 
 @:dce(ignore)
@@ -72,8 +63,9 @@ extern class Raylib {
 class Test {
     public static function main() {
         Raylib.InitWindow(800, 400, "raylib [core] example - basic window");
-
-        var target_x = Convert.float32(0.0);
+        var c = 10;
+        var b = c++;
+        var target_x:go.Float32 = 0.0;
         var target_y = Convert.float32(0.0);
         var vel_x = Convert.float32(0.0);
         var vel_y = Convert.float32(0.0);
@@ -109,7 +101,7 @@ class Test {
             Raylib.BeginDrawing();
             Raylib.ClearBackground(Raylib.White);
 
-            Raylib.DrawCircle(Convert.int32(target_x), Convert.int32(target_y), 20.0, Raylib.DarkGreen);
+            Raylib.DrawCircle(Convert.int32(target_x), Convert.int32(target_y), 20.0, Raylib.Red);
             Raylib.DrawCircle(Convert.int32(current_x), Convert.int32(current_y), 15.0, Raylib.Lime);
 
             Raylib.EndDrawing();

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -66,18 +66,18 @@ class Test {
         var c = 10;
         var b = c++;
         var target_x:go.Float32 = 0.0;
-        var target_y = Convert.float32(0.0);
-        var vel_x = Convert.float32(0.0);
-        var vel_y = Convert.float32(0.0);
-        var current_x = Convert.float32(0.0);
-        var current_y = Convert.float32(0.0);
+        var target_y:go.Float32 = 0.0;
+        var vel_x:go.Float32 = 0.0;
+        var vel_y:go.Float32 = 0.0;
+        var current_x:go.Float32 = 0.0;
+        var current_y:go.Float32 = 0.0;
 
-        final stiffness = Convert.float32(10.0);
-        final damping = Convert.float32(2.0);
+        final stiffness:go.Float32 = 10.0;
+        final damping:go.Float32 = 2.0;
 
         while (!Raylib.WindowShouldClose()) {
-            target_x = Convert.float32(Raylib.GetMouseX());
-            target_y = Convert.float32(Raylib.GetMouseY());
+            target_x = Raylib.GetMouseX();
+            target_y = Raylib.GetMouseY();
 
             var dx = current_x - target_x;
             var dy = current_y - target_y;

--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,5 +1,6 @@
 // NOTE: @:native causes the name to change in the dump file
 // We only want to use the metadata to point to the Go reference api
+import go.Float32;
 import go.Convert;
 @:go.package("fmt")
 @:go.native("fmt")
@@ -55,7 +56,7 @@ extern class Raylib {
     public static extern function GetMouseY(): Int;
 
     @:go.native("GetFrameTime")
-    public static extern function GetFrameTime(): go.Float32;
+    public static extern function GetFrameTime(): Float32;
 }
 
 @:dce(ignore)
@@ -65,15 +66,15 @@ class Test {
         Raylib.InitWindow(800, 400, "raylib [core] example - basic window");
         var c = 10;
         var b = c++;
-        var target_x:go.Float32 = 0.0;
-        var target_y:go.Float32 = 0.0;
-        var vel_x:go.Float32 = 0.0;
-        var vel_y:go.Float32 = 0.0;
-        var current_x:go.Float32 = 0.0;
-        var current_y:go.Float32 = 0.0;
+        var target_x:Float32 = 0.0;
+        var target_y:Float32 = 0.0;
+        var vel_x:Float32 = 0.0;
+        var vel_y:Float32 = 0.0;
+        var current_x:Float32 = 0.0;
+        var current_y:Float32 = 0.0;
 
-        final stiffness:go.Float32 = 10.0;
-        final damping:go.Float32 = 2.0;
+        final stiffness:Float32 = 10.0;
+        final damping:Float32 = 2.0;
 
         while (!Raylib.WindowShouldClose()) {
             target_x = Raylib.GetMouseX();


### PR DESCRIPTION
Go only allows explicit type casting for numbers, this PR makes the code for binops explicit, as well as adds resolver code to catch Haxe and hx2go stdlib types as a fallback.

I've focused pretty much exclusively on binops given our test code, perhaps a more general purpose solution would be better?

I also wasn't able to figure out how to get Haxe's abstracts to turn implicit casts to explicit casts with function ``@:from`` or ``@:to``.

I'd love a review from either one of you: @mikaib @elliott5 