### PR TITLE
Context: check if the module as the entryPointPath has a main def

### DIFF
--- a/source/Context.hx
+++ b/source/Context.hx
@@ -153,8 +153,17 @@ class Context {
         for (obj in _cache.keyValueIterator()) {
             final mod = obj.value;
             if (!compileList.contains(mod.path)) continue;
-            if (mod.path == options.entryPoint)
-                entryPointPath = obj.key;
+            if (mod.path == options.entryPoint) {
+                var isMain = false;
+                for (def in mod.defs) {
+                    if (def.name == "main") {
+                        isMain = true;
+                        break;
+                    }
+                }
+                if (isMain)
+                    entryPointPath = obj.key;
+            }
             for (def in mod.defs) {
                 if (def.isExtern) continue;
                 buf.add(def.buf.toString());


### PR DESCRIPTION
This fixes an issue where the entry path would be resolved incorrectly to a typedef rather then the needed static func main.