### PR TITLE
actions: matrix of haxe versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: ['1.21.3', 'oldstable', 'stable']
+        haxe-version: [latest, 4.3.7]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       # setup repo
@@ -26,7 +27,7 @@ jobs:
       # setup haxe
       - uses: krdlab/setup-haxe@v2.0.2
         with:
-          haxe-version: latest
+          haxe-version: ${{ matrix.haxe-version }}
       # Get the cores 
       - name: Get number of cores (Ubuntu)
         if: startsWith(runner.os, 'Linux')

--- a/source/HaxeExpr.hx
+++ b/source/HaxeExpr.hx
@@ -1,7 +1,6 @@
 package;
 
 import preprocessor.Scope;
-import haxe.runtime.Copy;
 import haxe.macro.Expr;
 
 enum abstract HaxeExprFlags(Int) from Int to Int {

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -21,8 +21,8 @@ class Transformer {
     public static function resultToTuple(p: TypePath): Void {
         p.name = "Tuple";
         p.params[0] = TPType(TAnonymous([
-            { name: "result", pos: #if haxe4 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
-            { name: "error", pos: #if haxe4 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
+            { name: "result", pos: #if (haxe_ver <= 4.37) 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
+            { name: "error", pos: #if (haxe_ver <= 4.37) 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
         ]));
         p.params.resize(1);
     }

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -21,8 +21,8 @@ class Transformer {
     public static function resultToTuple(p: TypePath): Void {
         p.name = "Tuple";
         p.params[0] = TPType(TAnonymous([
-            { name: "result", pos: p.pos, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
-            { name: "error", pos: p.pos, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
+            { name: "result", pos: #if haxe4 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
+            { name: "error", pos: #if haxe4 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
         ]));
         p.params.resize(1);
     }

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -21,8 +21,8 @@ class Transformer {
     public static function resultToTuple(p: TypePath): Void {
         p.name = "Tuple";
         p.params[0] = TPType(TAnonymous([
-            { name: "result", pos: #if (haxe_ver <= 4.37) null #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
-            { name: "error", pos: #if (haxe_ver <= 4.37) null #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
+            { name: "result", pos: null, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
+            { name: "error", pos: null, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
         ]));
         p.params.resize(1);
     }

--- a/source/transformer/Transformer.hx
+++ b/source/transformer/Transformer.hx
@@ -21,8 +21,8 @@ class Transformer {
     public static function resultToTuple(p: TypePath): Void {
         p.name = "Tuple";
         p.params[0] = TPType(TAnonymous([
-            { name: "result", pos: #if (haxe_ver <= 4.37) 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
-            { name: "error", pos: #if (haxe_ver <= 4.37) 0 #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
+            { name: "result", pos: #if (haxe_ver <= 4.37) null #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[0])) },
+            { name: "error", pos: #if (haxe_ver <= 4.37) null #else p.pos #end, kind: FVar(HaxeExprTools.typeOfParam(p.params[1])) }
         ]));
         p.params.resize(1);
     }


### PR DESCRIPTION
Haxe 4.3.7 and latest nightly is tested for now, anyone have an idea what other versions would be good to test against?

We are also limited to versions when custom platforms were introduced: https://github.com/HaxeFoundation/haxe/pull/11128