### PR TITLE
Type assertion on anon structs

### DIFF
--- a/source/transformer/exprs/FieldAccess.hx
+++ b/source/transformer/exprs/FieldAccess.hx
@@ -225,7 +225,8 @@ function handleFieldTransform(t:Transformer, e:HaxeExpr, ct:ComplexType, e2:Haxe
             t.def.addGoImport('unicode/utf8');
             true;
         case TAnonymous(fields):
-            e.def = EGoCode('{0}[{1}]', [e2, {def: EConst(CString(field)), t: ""}]);
+            e.def = EGoCode('{0}[{1}]', [e2, {def: EConst(CString(field)), t: "Dynamic"}]);
+            e.t = "Dynamic";
             true;
         case _:
             false;

--- a/source/translator/exprs/Cast.hx
+++ b/source/translator/exprs/Cast.hx
@@ -14,11 +14,21 @@ function translateCast(t:Translator, e:HaxeExpr, type:ComplexType) {
 
     var tStr = t.translateComplexType(type);
     var eStr = t.translateExpr(e);
-
+    switch e.t {
+        case "Dynamic": { 
+            return '(' + eStr + '.(' + tStr + '))';
+        }
+        default:
+    }
+    
     return switch (tStr) {
+        // pointer
         case _ if (path != null && tStr.charAt(0) == "*"): '((' + tStr + ')(' + eStr + '))';
+        // array access
         case _ if (path != null && tStr.startsWith('[')): '((' + tStr + ')(' + eStr + '))';
+        // no params type
         case _ if (path == null || (path.params == null || path.params.length == 0)): tStr + '(' + eStr + ')';
+        // default case
         case _: '((' + tStr + ')(' + eStr + '))';
     };
 }


### PR DESCRIPTION
```haxe

function main() {
	var s = {a: 77.8, b: " ... ", op: "+"};
	var f:Float = set(s.a + 1.1);
	Sys.println(s + " " + f);
}

function set(x:Float):Float
	return x;
```


Before:
```go
float64(s["a"])
```
After:
```go
(s["a"].(float64))
```