### PR TITLE
Jump to comment

### DIFF
--- a/source/HaxeExpr.hx
+++ b/source/HaxeExpr.hx
@@ -276,6 +276,7 @@ class HaxeField {
 	public var t:String;
 	public var expr:HaxeExpr;
 	public var meta:Array<MetadataEntry>;
+	public var pos:Position;
 }
 
 enum HaxeFieldKind {

--- a/source/parser/dump/RecordTools.hx
+++ b/source/parser/dump/RecordTools.hx
@@ -77,6 +77,7 @@ function recordToHaxeTypeDefinition(record: RecordEntry):HaxeTypeDefinition {
             name: c.get("cf_name"),
             kind: FFun({ args: [], params: params }),
             t: "#UNKNOWN_TYPE",
+            pos: null,
             expr: c.get("cf_expr"),
             meta: getMeta(c.get("cf_meta")),
         };
@@ -127,6 +128,7 @@ private function recordClassFieldToHaxeField(record_debug_path:String, field:Rec
     return {
         name: field.name,
         kind: kind,
+        pos: field.pos,
         t: "#UNKNOWN_TYPE",
         expr: field.expr,
         meta: getMeta(field.meta),

--- a/source/translator/Translator.hx
+++ b/source/translator/Translator.hx
@@ -107,6 +107,8 @@ class Translator {
                             throw "expr.def is not EFunction: " + expr.def;
                     }
                 case FVar:
+                    if (field.pos != null)
+                        buf.add(commentJumpTo(field.pos));
                     buf.add('var $name'); // TODO: typing
                     if (expr != null)
                         buf.add(translateExpr(expr));

--- a/source/translator/Translator.hx
+++ b/source/translator/Translator.hx
@@ -1,5 +1,9 @@
 package translator;
 
+import sys.FileSystem;
+import haxe.io.Path;
+import sys.io.File;
+import haxe.macro.PositionTools;
 import haxe.macro.Printer;
 import haxe.macro.Expr;
 import translator.exprs.*;
@@ -95,6 +99,8 @@ class Translator {
                 case FFun(_):
                     switch expr.def {
                         case EFunction(kind, f):
+                            if (field.pos != null)
+                                buf.add(commentJumpTo(field.pos));
                             buf.add(translator.exprs.Function.translateFunction(this, name, f));
                         default:
                             Logging.translator.error('expr.def failure field:' + field.name);
@@ -115,4 +121,27 @@ class Translator {
         }
         return buf.toString();
     }
+}
+
+private function toLocationLine(pos:Position):Int {
+    final lines = Util.normalizeCLRF(File.getContent(pos.file)).split("\n");
+    var current = 0;
+    for (i in 0...lines.length) {
+        if (current + lines[i].length > pos.min) {
+            return i + 1;
+        }
+        current += lines[i].length + 1;
+    }
+    return 0;
+}
+
+private function commentJumpTo(pos:Position):String {
+    final isWindows = Sys.systemName().toLowerCase() == "windows";
+    final path = FileSystem.absolutePath(pos.file);
+    var location = path + "#L" + toLocationLine(pos);
+    if (isWindows) {
+        location = haxe.io.Path.normalize(location);
+        location = "/" + location;
+    }
+    return '//file://$location\n';
 }


### PR DESCRIPTION
Adds jump comments in the source code to definitions.
```go
package main

import "fmt"
import "time"

//file://testbed/Test.hx#L2
var Hx__test_test_fields__I_ = 10
//file://testbed/Test.hx#L4
func Hx__test_test_fields__Main()  {
    Hx_sys_Println("hello")
}
//file://Sys.go.hx#L7
func Hx_sys_Println[T any](v T)  {
    fmt.Println(v)
}
//file://Sys.go.hx#L10
func Hx_sys_Print[T any](v T)  {
    fmt.Print(v)
}
//file://Sys.go.hx#L13
func Hx_sys_Sleep(seconds float64)  {
    time.Sleep(time.Second * time.Duration(seconds))
}
func main() {
	Hx__test_test_fields__Main()
}
```