### PR TITLE
Integer division

### DIFF
--- a/testbed/Test.hx
+++ b/testbed/Test.hx
@@ -1,3 +1,6 @@
 function main() {
-	Sys.println("hello" + 10 + "hi" + 10.3);
+    Sys.println(get()/5 == 0.6);
 }
+
+function get()
+    return 3;


### PR DESCRIPTION
3/5 returns 0.6 in Haxe and normally 0 in Go unless we cast to Float before doing the division operation, this PR adds in the needed casting.