### PR TITLE
Switch add default case and be able to translate cases in…

### DIFF
--- a/source/parser/dump/ExprParser.hx
+++ b/source/parser/dump/ExprParser.hx
@@ -283,6 +283,22 @@ class ExprParser {
             case SWITCH:
                 var cases = object.objects.copy(); // [on, case, case]
                 var on = objectToExpr(cases.shift()); // on, [case, case]
+                final lastCase = if (cases.length > 0) {
+                    cases.pop();
+                }else{
+                    null;
+                }
+
+                final defaultCase = if(lastCase != null && lastCase.def == DEFAULT) {
+                    objectToExpr(lastCase.objects[0]);
+                }else{
+                    // put back
+                    if (lastCase != null)
+                        cases.push(lastCase);
+                    // no default case
+                    null;
+                }
+
 
                 // mikaib: haxe seems to be very eager on reordering switch cases, so thus far I've been unable to get a dump which defines a guard or more than 1 value per case.
                 // it may only be generated in very specific situations, or perhaps the dump is in a form where that info is lost.
@@ -298,7 +314,7 @@ class ExprParser {
                         guard: emptyExpr(),
                         expr: c.objects.length > 1 ? objectToExpr(c.objects[1]) : emptyExpr(),
                     }
-                }), null);
+                }), defaultCase);
 
             case THROW:
                 EThrow(objectToExpr(object.objects[0]));
@@ -358,6 +374,7 @@ class ExprParser {
                 });
                 //objectToExpr(object.objects[object.objects.length - 1]).def;
             default:
+                Logging.exprParser.warn("not implemented expr def: " + object.def);
                 //throw "not implemented expr: " + object.def;
                 if (!nonImpl.contains(object.def)) nonImpl.push(object.def);
                 EConst(CIdent("#objectToExpr_" + object.string()));

--- a/source/translator/Translator.hx
+++ b/source/translator/Translator.hx
@@ -88,6 +88,8 @@ class Translator {
                     Throw.translateThrow(this, e);
                 case EContinue:
                     Continue.translateContinue(this);
+                case ESwitch(e, cases, edef):
+                    Switch.translateSwitch(this, e, cases, edef);
                 default:
                     //trace("UNKNOWN EXPR TO TRANSLATE:" + e.def);
                     "_ = 0";

--- a/source/translator/exprs/Switch.hx
+++ b/source/translator/exprs/Switch.hx
@@ -1,0 +1,37 @@
+package translator.exprs;
+
+function translateSwitch(t:Translator, e:HaxeExpr, cases:Array<HaxeExpr.HaxeCase>, edef:Null<HaxeExpr>):String{
+    final buf = new StringBuf();
+    if (cases.length != 0) {
+        buf.add("if ");
+        var elseIfBool = false;
+        for (c in cases) {
+            if (elseIfBool)
+                buf.add(" else if ");
+            for (value in c.values) {
+                final expr:HaxeExpr = {def: EBinop(OpEq, e, value), t: value.t};
+                t.module.transformer.transformExpr(expr);
+                buf.add(t.translateExpr(expr));
+            }
+            if (c.guard != null && !c.guard.def.match(EBlock(_))) {
+                if (c.values.length != 0) {
+                    buf.add(" && ");
+                }
+                buf.add(t.translateExpr(c.guard));
+            }
+            // buf.add(" {\n");
+            if (c.expr != null)
+                buf.add(t.translateExpr(c.expr));
+            // buf.add("}");
+            elseIfBool = true;
+        }
+
+    }
+    if (edef != null) {
+        if (cases.length > 0)
+            buf.add(" else ");
+        buf.add(t.translateExpr(edef));
+    }
+
+    return buf.toString();
+}


### PR DESCRIPTION
…cluding with guards

```haxe

function main() {
    var x = get();
    switch x {
        case 1:
            trace(1);
        case 2:
            trace(2);
    }
    switch x {
        case 2:
        case 3:
        case 4:
        default:
            trace("def");
    }
    switch x {

    }
    switch x {
        case 1 if (x == 2 && get() == 1) :
            trace("1!");
    }
}

function get() {
    return 1;
}

```

