### PR TITLE
ci: workaround Go runtime GC bug (golang/go#80188)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    env:
+      # Workaround for Go runtime GC bug (golang/go#80188) causing intermittent
+      # "s.allocCount != s.nelems" crashes. Remove once Go 1.26.6+ is stable.
+      GODEBUG: asyncpreemptoff=1
     strategy:
       matrix:
         go-version: ['stable']


### PR DESCRIPTION
Set GODEBUG=asyncpreemptoff=1 to prevent intermittent 's.allocCount != s.nelems' crashes on windows CI.
Remove once Go 1.26.6+ is the stable version.