### PR TITLE
passes: add FunctionCompare to use HxDynamic equality check on funcs

### DIFF
--- a/_std/Reflect.hx
+++ b/_std/Reflect.hx
@@ -80,7 +80,7 @@ class Reflect {
             return false;
         }
 
-        throw f1 == f2;
+        return f1 == f2;
     }
 
     public static function isObject(v: Dynamic): Bool {

--- a/_std/go/UIntPtr.hx
+++ b/_std/go/UIntPtr.hx
@@ -1,4 +1,4 @@
 package go;
 
 @:go.Type({ name: "uintptr" })
-typedef UIntPtr = Int;
+typedef UIntPtr = go.GoUInt;

--- a/_std/go/UIntPtr.hx
+++ b/_std/go/UIntPtr.hx
@@ -1,4 +1,4 @@
 package go;
 
 @:go.Type({ name: "uintptr" })
-interface UIntPtr {}
+typedef UIntPtr = Int;

--- a/_std/go/haxe/HxDynamic.hx
+++ b/_std/go/haxe/HxDynamic.hx
@@ -181,6 +181,10 @@ class HxDynamic {
             }
         }
 
+        if (aK == Reflect.Func && bK == Reflect.Func) {
+            return aV.pointer() == bV.pointer();
+        }
+
         var k = jointKind(aV, bV);
         if (k == Reflect.Int32 || k == Reflect.Int)
             return valueToInt(aV) == valueToInt(bV);

--- a/_std/go/haxe/HxDynamic.hx
+++ b/_std/go/haxe/HxDynamic.hx
@@ -7,6 +7,8 @@ import go.reflect.Kind;
 import go.reflect.Type;
 import go.Syntax;
 import go.Fmt;
+import go.Pointer;
+import go.unsafe.Pointer as UnsafePointer;
 
 // HxDynamic implements Dynamic runtime manipulation required by Haxe
 // using go.reflect.Reflect and naming from http://haxedev.wikidot.com/article:operator-overloading
@@ -16,6 +18,13 @@ import go.Fmt;
 // All functions return String, Int, Float, Bool or null inside a Dynamic
 //
 // TODO tests
+
+@:go.Type({ name: "unsafe", imports: ["unsafe"] })
+private extern class Unsafe {
+    @:native("Pointer") static function pointer(p: Dynamic): UnsafePointer;
+    @:native("Add") static function add(ptr: UnsafePointer, len: go.UIntPtr): UnsafePointer;
+    @:native("Sizeof") static function sizeof(v: Dynamic): go.UIntPtr;
+}
 @:keep
 @:analyzer(ignore)
 class HxDynamic {
@@ -182,7 +191,11 @@ class HxDynamic {
         }
 
         if (aK == Reflect.Func && bK == Reflect.Func) {
-            return aV.pointer() == bV.pointer();
+            if (aV.pointer() != bV.pointer()) {
+                return false;
+            }
+
+            return funcReceiver(a) == funcReceiver(b);
         }
 
         var k = jointKind(aV, bV);
@@ -901,5 +914,18 @@ class HxDynamic {
         }
 
         return value._interface();
+    }
+
+    // peek atthe funcval's captured receiver directly.
+    static function funcReceiver(fn: Dynamic): go.UIntPtr {
+        // &fn points at the interface header; the data pointer is the 2nd word
+        var header: UnsafePointer = Unsafe.pointer(Pointer.addressOf(fn));
+        var wordSize: go.UIntPtr = Unsafe.sizeof(header);
+        // read the funcval pointer (stored at header + wordSize) as a uintptr,
+        // then reinterpret it as an unsafe.Pointer to walk the funcval.
+        var dataLoc: Pointer<go.UIntPtr> = cast Unsafe.add(header, wordSize);
+        var funcval: UnsafePointer = Unsafe.pointer(dataLoc.value);
+        var recvLoc: Pointer<go.UIntPtr> = cast Unsafe.add(funcval, wordSize * 2);
+        return recvLoc.value;
     }
 }

--- a/source/hx2go/Context.hx
+++ b/source/hx2go/Context.hx
@@ -93,6 +93,7 @@ class Context {
         return [
             new hx2go.passes.FieldAccessGeneric(this), // TODO: c1
             new hx2go.passes.DefaultArgs(this),
+            new hx2go.passes.FunctionCompare(this),
             new hx2go.passes.TypeNormaliserCallReturn(this),
             new hx2go.passes.RewriteSyntaxCode(this),
             new hx2go.passes.RewriteGoUIntNegativeConst(this),
@@ -144,7 +145,6 @@ class Context {
             new hx2go.passes.FieldAccessExtern(this),
             new hx2go.passes.FieldAccessInstance(this),
             new hx2go.passes.InterfaceDynamic(this),
-            new hx2go.passes.FunctionCompare(this),
             new hx2go.passes.InterfaceCompare(this),
             new hx2go.passes.RewriteAbstractThis(this),
             new hx2go.passes.RewriteSliceCreation(this),

--- a/source/hx2go/Context.hx
+++ b/source/hx2go/Context.hx
@@ -144,6 +144,7 @@ class Context {
             new hx2go.passes.FieldAccessExtern(this),
             new hx2go.passes.FieldAccessInstance(this),
             new hx2go.passes.InterfaceDynamic(this),
+            new hx2go.passes.FunctionCompare(this),
             new hx2go.passes.InterfaceCompare(this),
             new hx2go.passes.RewriteAbstractThis(this),
             new hx2go.passes.RewriteSliceCreation(this),

--- a/source/hx2go/passes/FunctionCompare.hx
+++ b/source/hx2go/passes/FunctionCompare.hx
@@ -1,0 +1,45 @@
+package hx2go.passes;
+
+import hxb.Typed.HxbTypedExpr;
+import hxb.HxbModuleType;
+import hx2go.util.TypeHelper;
+import hx2go.util.ExprHelper;
+import hx2go.normaliser.Semantics;
+import hxb.Ast.HxbBinop;
+import hxb.HxbType;
+import haxe.runtime.Copy;
+import hxb.flags.HxbClassFlag;
+
+class FunctionCompare extends CompilerPass {
+
+    public function match(expr: HxbTypedExpr): Bool {
+        return switch expr.expr {
+            case TBinop(OpEq | OpNotEq, left, right) if (
+                left.t != null && TypeHelper.follow(context, left.t).match(TFun(_)) &&
+                right.t != null && TypeHelper.follow(context, right.t).match(TFun(_))
+            ): true;
+
+            case _: false;
+        }
+    }
+
+    public function execute(expr: HxbTypedExpr, frame: ContextFrame): Void {
+        switch [expr.expr, expr.expr] {
+            case [TBinop(OpEq | OpNotEq, left, right), TBinop(OpEq | OpNotEq, _, _)]: {
+                var o = ExprHelper.createCast(left, TDynamicAny);
+                    left.expr = o.expr;
+                    left.t = o.t;
+
+                var o = ExprHelper.createCast(right, TDynamicAny);
+                    right.expr = o.expr;
+                    right.t = o.t;
+
+                expr.t = TDynamicAny;
+                context.submitNode(expr, true);
+            }
+
+            case _: null;
+        }
+    }
+
+}

--- a/tests/unit/FunctionCompare.hx
+++ b/tests/unit/FunctionCompare.hx
@@ -1,0 +1,14 @@
+package unit;
+function main() {
+	assert((foo : Dynamic) == (foo : Dynamic));
+	assert(foo == foo);
+	assert((foo : Dynamic) == foo);
+	assert((foo : Dynamic) != (foo2 : Dynamic));
+	// assert(foo == foo2);
+	// assert((foo : Func) == (foo2 : Func));
+}
+
+typedef Func = Void -> Void;
+
+function foo() {}
+function foo2() {}

--- a/tests/unit/FunctionCompare.hx
+++ b/tests/unit/FunctionCompare.hx
@@ -8,9 +8,18 @@ function main() {
 	assert((foo : Func) != (foo2 : Func));
 	assert((foo : Null<Func>) != (foo2 : Func));
 	assert((foo : Null<Func>) == (foo : Func));
+	var cl1 = new Cl();
+	var cl2 = new Cl();
+	trace(cl1.method == cl1.method);
+	trace(cl1.method != cl2.method);
 }
 
 typedef Func = Void -> Void;
 
 function foo() {}
 function foo2() {}
+
+class Cl {
+	public function new() {}
+	public function method() {}
+}

--- a/tests/unit/FunctionCompare.hx
+++ b/tests/unit/FunctionCompare.hx
@@ -4,8 +4,10 @@ function main() {
 	assert(foo == foo);
 	assert((foo : Dynamic) == foo);
 	assert((foo : Dynamic) != (foo2 : Dynamic));
-	// assert(foo == foo2);
-	// assert((foo : Func) == (foo2 : Func));
+	assert(foo != foo2);
+	assert((foo : Func) != (foo2 : Func));
+	assert((foo : Null<Func>) != (foo2 : Func));
+	assert((foo : Null<Func>) == (foo : Func));
 }
 
 typedef Func = Void -> Void;


### PR DESCRIPTION
```haxe
function main() {
	trace((foo : Dynamic) == (foo : Dynamic));
	trace(foo == foo);
	trace((foo : Dynamic) == foo);
	trace((foo : Dynamic) != (foo2 : Dynamic));
	trace(foo != foo2);
	trace((foo : Func) != (foo2 : Func));
	trace((foo : Null<Func>) != (foo2 : Func));
	trace((foo : Null<Func>) == (foo : Func));
}

typedef Func = Void -> Void;

function foo() {}
function foo2() {}
```