### PR TITLE
Extern examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,9 @@ jobs:
         
       - name: Extern tests
         run: cd hx2go-extern && haxe Testbed.hxml
+
+      - name: Test examples
+        run: haxe scripts/test_examples.hxml
       
       - name: Go stdlib include test
         run: haxe scripts/include_gen.hxml

--- a/examples/asciigraph/Main.hx
+++ b/examples/asciigraph/Main.hx
@@ -1,0 +1,7 @@
+import go.github_com.guptarohit.Asciigraph;
+
+function main() {
+	var data:Array<Float> = [3, 4, 9, 6, 2, 4, 5, 8, 5, 10, 2, 7, 2, 5, 6];
+	var graph:String = Asciigraph.plot(data);
+	trace("\n" + graph);
+}

--- a/examples/asciigraph/build.hxml
+++ b/examples/asciigraph/build.hxml
@@ -1,0 +1,6 @@
+-cp examples/asciigraph
+-m Main
+-L hx2go
+-D go-lib=github.com/guptarohit/asciigraph
+--custom-target go=output/examples/asciigraph
+--cmd go -C output/examples/asciigraph/main run .

--- a/examples/ebiten/Main.hx
+++ b/examples/ebiten/Main.hx
@@ -1,0 +1,43 @@
+import go.github_com.hajimehoshi.ebiten.v2.Ebitenutil;
+import go.github_com.hajimehoshi.ebiten.v2.Ebiten;
+import go.github_com.hajimehoshi.ebiten.v2.Image;
+import go.Pointer;
+import go.GoInt;
+import go.Error;
+import go.Tuple;
+
+class Game {
+
+    public function new() {
+        return;
+    }
+
+    @:go.Export
+    public function draw(screen: Pointer<Image>): Void {
+        Ebitenutil.debugPrint(screen, "Hello, World!");
+    }
+
+    var count = 0;
+
+    @:go.Export
+    public function update(): Error {
+        count++;
+        if (count > 60 * 5) {
+            Sys.exit(0);
+        }
+        return null;
+    }
+
+    @:go.Export
+    @:go.Tuple("screenWidth", "screenHeight")
+    public function layout(outsideWidth: GoInt, outsideHeight: GoInt): Tuple<{ screenWidth: GoInt, screenHeight: GoInt }> {
+        return { screenWidth: 640, screenHeight: 480 };
+    }
+
+}
+
+function main() {
+    Ebiten.setWindowSize(640, 480);
+    Ebiten.setWindowTitle("Hello, World!");
+    Ebiten.runGame(new Game()).sure();
+}

--- a/examples/ebiten/build.hxml
+++ b/examples/ebiten/build.hxml
@@ -1,0 +1,6 @@
+-cp examples/ebiten
+-m Main
+-L hx2go
+-D go-lib=github.com/hajimehoshi/ebiten/...
+--custom-target go=output/examples/ebiten
+--cmd go -C output/examples/ebiten/main run .

--- a/examples/ebiten/build.hxml
+++ b/examples/ebiten/build.hxml
@@ -1,6 +1,6 @@
 -cp examples/ebiten
 -m Main
 -L hx2go
--D go-lib=github.com/hajimehoshi/ebiten/...
+-D go-lib=github.com/hajimehoshi/ebiten/v2/...
 --custom-target go=output/examples/ebiten
 --cmd go -C output/examples/ebiten/main run .

--- a/examples/go_lua/Main.hx
+++ b/examples/go_lua/Main.hx
@@ -1,0 +1,7 @@
+import go.github_com.shopify.go_lua.Lua;
+
+function main() {
+    var l = Lua.newState();
+    Lua.openLibraries(l);
+    Lua.doString(l, 'print("hello world")').sure();
+}

--- a/examples/go_lua/build.hxml
+++ b/examples/go_lua/build.hxml
@@ -1,0 +1,6 @@
+-cp examples/go_lua
+-m Main
+-L hx2go
+-D go-lib=github.com/Shopify/go-lua/...
+--custom-target go=output/examples/go_lua
+--cmd go -C output/examples/go_lua/main run .

--- a/examples/gorm/Main.hx
+++ b/examples/gorm/Main.hx
@@ -1,0 +1,41 @@
+import go.Os;
+import go.gorm_io.gorm.Model;
+import go.gorm_io.Gorm;
+import go.gorm_io.driver.Sqlite;
+import sys.FileSystem;
+
+function main() {
+    if (FileSystem.exists("test.db")) {
+        FileSystem.deleteFile("test.db");
+    }
+
+    var db = Gorm.open(Sqlite.open("test.db")).sure();
+    db.autoMigrate(new Product());
+
+    db.create(new Product("D42", 100));
+
+    var product = new Product();
+    db.first(product, 1); // find product with integer primary key
+    db.first(product, "hx_field_code = ?", "D42");
+
+    // update single field
+    db.model(product).update("hx_field_price", 200);
+    // update multiple fields
+    db.model(product).updates(new Product("F42", 200));
+    db.model(product).updates({hx_field_price: 200, hx_field_code: "F43"});
+    // delete
+    db.delete(product, 1);
+
+}
+
+@:structInit
+class Product {
+    @:go.Tag('gorm:"embedded"')
+    public var model:Model;
+    public var code:String;
+    public var price:UInt;
+    public function new(code="", price=0) {
+        this.code = code;
+        this.price = price;
+    }
+}

--- a/examples/gorm/build.hxml
+++ b/examples/gorm/build.hxml
@@ -1,0 +1,7 @@
+-cp examples/gorm
+-m Main
+-L hx2go
+-D go-lib=gorm.io/gorm/...
+-D go-lib=gorm.io/driver/sqlite/...
+--custom-target go=output/examples/gorm
+--cmd go -C output/examples/gorm/main run .

--- a/examples/gtk/Main.hx
+++ b/examples/gtk/Main.hx
@@ -1,0 +1,20 @@
+import go.github_com.diamondburned.gotk4.pkg.gtk.v4.Gtk;
+import go.github_com.diamondburned.gotk4.pkg.gtk.v4.Application;
+
+class Main {
+	static function main() {
+		var app = Gtk.newApplication("com.github.diamondburned.gotk4-examples.gtk4.simple", 0b0);
+		app.connectActivate(() -> {
+			activate(app);
+		});
+		app.run([]);
+	}
+
+	static function activate(app:Application) {
+		var window = Gtk.newApplicationWindow(app);
+		window.setTitle("gotk4 Example");
+		window.setChild(Gtk.newLabel("Hello from Go!"));
+		window.setDefaultSize(400, 300);
+		window.show();
+	}
+}

--- a/examples/gtk/build.hxml
+++ b/examples/gtk/build.hxml
@@ -1,0 +1,6 @@
+-cp examples/gtk
+-m Main
+-L hx2go
+-D go-lib=github.com/diamondburned/gotk4/pkg/...
+--custom-target go=output/examples/gtk
+--cmd go -C output/examples/gtk/main run .

--- a/examples/http_fileserver/Main.hx
+++ b/examples/http_fileserver/Main.hx
@@ -1,0 +1,13 @@
+import go.net.Http;
+import go.net.http.Dir;
+
+function main() {
+	var port = ":8082";
+	trace('http file server: http://localhost$port');
+
+	var dir:Dir = ".";
+	var err = Http.listenAndServe(port, Http.fileServer(dir));
+	trace(err);
+	// NOTE: the server will continue to run until interrupted.
+	// Polite shutdown is beyond the scope of this simple example.
+}

--- a/examples/http_fileserver/build.hxml
+++ b/examples/http_fileserver/build.hxml
@@ -1,0 +1,6 @@
+-cp examples/http_fileserver
+-m Main
+-L hx2go
+# as this code calls the Go standard library, there is no need for a '-D go-lib=' entry here
+--custom-target go=output/examples/http_fileserver
+--cmd go -C output/examples/http_fileserver/main run .

--- a/examples/miqt/Main.hx
+++ b/examples/miqt/Main.hx
@@ -1,0 +1,19 @@
+import go.github_com.mappu.miqt.Qt;
+import go.Os;
+
+function main() {
+    Qt.newQApplication(Os.args);
+
+    var btn = Qt.newQPushButton3("Hello World!");
+    btn.setFixedWidth(320);
+
+    var counter = 0;
+    btn.onPressed(() -> {
+        counter++;
+        btn.setText('You have clicked the button $counter time(s)!');
+    });
+
+    btn.show();
+
+    Qt.qApplication_Exec();
+}

--- a/examples/miqt/build.hxml
+++ b/examples/miqt/build.hxml
@@ -1,0 +1,6 @@
+-cp examples/miqt
+-m Main
+-L hx2go
+-D go-lib=github.com/mappu/miqt/...
+--custom-target go=output/examples/miqt
+--cmd go -C output/examples/gorm/miqt run .

--- a/scripts/TestExamples.hx
+++ b/scripts/TestExamples.hx
@@ -1,11 +1,14 @@
 function main() {
 	for (dir in sys.FileSystem.readDirectory("examples")) {
 		// skip
-		if (dir == "miqt" || dir == "gtk" || dir == "http_fileserver") {
-			continue;
+		switch dir {
+			case "miqt", "gtk", "http_fileserver", "ebiten"
+				continue;
 		}
 		// run
-		var code = Sys.command('haxe examples/$dir/build.hxml');
+		var command = 'haxe examples/$dir/build.hxml';
+		Sys.println(command);
+		var code = Sys.command(command);
 		if (code != 0)
 			Sys.exit(code);
 	}

--- a/scripts/TestExamples.hx
+++ b/scripts/TestExamples.hx
@@ -1,12 +1,12 @@
 function main() {
-    for (dir in sys.FileSystem.readDirectory("examples")) {
-        // skip
-        if (dir == "miqt" || dir == "gtk") {
-            continue;
-        }
-        // run
-        var code = Sys.command('haxe examples/$dir/build.hxml');
-        if (code != 0)
-            Sys.exit(code);
-    }
+	for (dir in sys.FileSystem.readDirectory("examples")) {
+		// skip
+		if (dir == "miqt" || dir == "gtk" || dir == "http_fileserver") {
+			continue;
+		}
+		// run
+		var code = Sys.command('haxe examples/$dir/build.hxml');
+		if (code != 0)
+			Sys.exit(code);
+	}
 }

--- a/scripts/TestExamples.hx
+++ b/scripts/TestExamples.hx
@@ -2,8 +2,9 @@ function main() {
 	for (dir in sys.FileSystem.readDirectory("examples")) {
 		// skip
 		switch dir {
-			case "miqt", "gtk", "http_fileserver", "ebiten"
+			case "miqt", "gtk", "http_fileserver", "ebiten":
 				continue;
+			default:
 		}
 		// run
 		var command = 'haxe examples/$dir/build.hxml';

--- a/scripts/TestExamples.hx
+++ b/scripts/TestExamples.hx
@@ -1,0 +1,12 @@
+function main() {
+    for (dir in sys.FileSystem.readDirectory("examples")) {
+        // skip
+        if (dir == "miqt" || dir == "gtk") {
+            continue;
+        }
+        // run
+        var code = Sys.command('haxe examples/$dir/build.hxml');
+        if (code != 0)
+            Sys.exit(code);
+    }
+}

--- a/scripts/test_examples.hxml
+++ b/scripts/test_examples.hxml
@@ -1,0 +1,3 @@
+-cp scripts
+-m TestExamples
+--interp


### PR DESCRIPTION
Adds a new folder ``examples`` in root to show how to use extern Go libraries in Haxe, and to run in CI to prevent regressions.

We also might want to add ``net/http`` and other useful Go stdlib examples.

I also think we shouldn't add everything under the sun into ``examples`` the criteria should either be as a regression test for a previously failing extern library or useful for Haxe devs + widely used.

Off the top of my head what would be great additions would be:
- bubbletea (terminal user interface)
- goja (javascript engine in pure Go)
- harmonica (physics based animations)
- tetra3d (we made a game in it [haha](https://pxshadow.itch.io/horse-clanker))
- mysql
- pion (webrtc)
- wazero (zero dep wasm runtime)
- esbuild (js bundler with Go api)
- zap (structured logging)
- nats (messaging system similar to elixir)
- pgx (postgress support)
- go-echarts (chart support, we use this for our Haxe unit test chart)
- opencv (computer vision)
- gopdf (pdf generation)
- go-humanize (human readable number generation)
- chroma (syntax highlighting)
- mpb (multi progress bar)