### PR TITLE
Various fixes for running the wisdom library (fixes #174)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,8 @@ jobs:
         
       - name: Extern tests
         run: cd hx2go-extern && haxe Testbed.hxml
-
+      - name: Install libraries for examples
+        run: haxelib git wisdom https://github.com/jeremyfa/wisdom
       - name: Test examples
         run: haxe scripts/test_examples.hxml
       

--- a/_std/go/haxe/HxDynamic.hx
+++ b/_std/go/haxe/HxDynamic.hx
@@ -623,6 +623,33 @@ class HxDynamic {
         return cls.addr()._interface();
     }
 
+    // if mismatch, throw instead of returning nil
+    public static function castClass(d: Dynamic, className: String): Dynamic {
+        if (isNull(d)) {
+            return null;
+        }
+
+        var v = ensureValue(d);
+        var cls = valueToClass(v, className);
+        if (!cls.isValid()) {
+            throw "Can't cast " + v.type().string() + " to " + className;
+        }
+
+        // already the class reference.
+        if (cls.kind() == Reflect.ptr) {
+            return cls._interface();
+        }
+
+        // return a pointer to the value
+        if (!cls.canAddr()) {
+            var boxed = Reflect._new(cls.type());
+            boxed.elem().set(cls);
+            return boxed._interface();
+        }
+
+        return cls.addr()._interface();
+    }
+
     static function isNullableType(t: Type): Bool {
         if (t.kind() != Reflect.struct || t.numField() != 2 || t.name() != "") {
             return false;

--- a/examples/wisdom/Test.hx
+++ b/examples/wisdom/Test.hx
@@ -1,5 +1,5 @@
 package;
-
+// This file is dual liscensed with MIT/ZLib
 import wisdom.Node;
 import haxe.xml.Access;
 import wisdom.VNode;

--- a/examples/wisdom/Test.hx
+++ b/examples/wisdom/Test.hx
@@ -1,0 +1,283 @@
+package;
+
+import wisdom.Node;
+import haxe.xml.Access;
+import wisdom.VNode;
+import wisdom.Wisdom;
+import wisdom.X;
+import wisdom.modules.AttributesModule;
+import wisdom.modules.ClassModule;
+import wisdom.modules.ListenersModule;
+import wisdom.modules.PropsModule;
+import wisdom.modules.StyleModule;
+
+// custom backend file
+import haxe.Constraints.Function;
+import wisdom.Node;
+import wisdom.Element;
+import wisdom.CreateElementOptions;
+import wisdom.Text;
+import wisdom.Comment;
+import wisdom.VNode;
+import wisdom.VNodeData;
+import wisdom.Xid;
+import wisdom.HtmlAttributes;
+import wisdom.SvgAttributes;
+
+using StringTools;
+
+// https://gist.github.com/l0go/7bbccea6c96625e7c0bd768f171b7f91
+class StaticWisdomBackend extends wisdom.Backend {
+	public function new() {}
+
+	public function createElement(tagName: String, ?options: CreateElementOptions #if wisdom_debug, ?pos: haxe.PosInfos #end): Element {
+		var element = Xml.createElement(tagName);
+		if (untyped options.is != null) {
+			element.set("is", untyped options.is);
+		}
+		return cast element;
+	}
+
+	public function createElementNS(namespaceUri: String, qualifiedName: String, ?options: CreateElementOptions
+			#if wisdom_debug, ?pos: haxe.PosInfos #end): Element {
+		final parts = qualifiedName.split(":");
+		var element = Xml.createElement(qualifiedName);
+
+		if (parts.length > 1) {
+			element.set('xmlns:${parts[0]}', namespaceUri);
+		} else {
+			element.set("xmlns", namespaceUri);
+		}
+
+		if (untyped options.is != null) {
+			element.set("is", untyped options.is);
+		}
+		return cast element;
+	}
+
+	public function createTextNode(text: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Text {
+		return cast Xml.createPCData(text);
+	}
+
+	public function createComment(text: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Comment {
+		return cast Xml.createComment(text);
+	}
+
+	public function insertBefore(parentNode: Node, newNode: Node, referenceNode: Null<Node> #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final parentNodeXml: Xml = cast parentNode;
+		final newNodeXml: Xml = cast newNode;
+		if (referenceNode == null) {
+			parentNodeXml.addChild(newNodeXml);
+			return;
+		}
+		final referenceNodeXml: Xml = cast referenceNode;
+
+		if (referenceNodeXml.parent != parentNodeXml) {
+			throw "Reference node is not a child of the parent";
+		}
+
+		if (newNodeXml.parent != null) {
+			newNodeXml.parent.removeChild(newNodeXml);
+		}
+
+		final children = [for (x in parentNodeXml.iterator()) x];
+		final index = children.indexOf(referenceNodeXml);
+		if (index == -1) {
+			throw "Reference node not found in parent's children";
+		}
+		children.insert(index, newNodeXml);
+
+		for (x in parentNodeXml.iterator()) {
+			parentNodeXml.removeChild(x);
+		}
+
+		for (child in children) {
+			parentNodeXml.addChild(child);
+		}
+	}
+
+	public function removeChild(node: Node, child: Node #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final nodeXml: Xml = cast node;
+		nodeXml.removeChild(cast child);
+	}
+
+	public function appendChild(node: Node, child: Node #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final nodeXml: Xml = cast node;
+		nodeXml.addChild(cast child);
+	}
+
+	public function parentNode(node: Node): Null<Node> {
+		final nodeXml: Xml = cast node;
+		return cast nodeXml.parent;
+	}
+
+	public function nextSibling(node: Node): Null<Node> {
+		final nodeXml: Xml = cast node;
+		final children = [for (x in nodeXml.parent.iterator()) x];
+		final index = children.indexOf(nodeXml);
+		return cast children[index + 1];
+	}
+
+	public function tagName(elm: Element): String {
+		final nodeXml: Xml = cast elm;
+		return nodeXml.nodeName;
+	}
+
+	public function setTextContent(node: Node, text: Null<String> #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final nodeXml: Xml = cast node;
+		final children = [for (x in nodeXml.parent.iterator()) x];
+		for (child in children) {
+			if (child.nodeType == PCData) {
+				nodeXml.nodeValue = text;
+			}
+		}
+	}
+
+	public function getTextContent(node: Node): Null<String> {
+		final nodeXml: Xml = cast node;
+		final children = [for (x in nodeXml.parent.iterator()) x];
+		for (child in children) {
+			if (child.nodeType == PCData) {
+				return child.nodeValue;
+			}
+		}
+		return null;
+	}
+
+	public function addClass(elm: Element, name: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final elmXml: Xml = cast elm;
+		elmXml.set("class", ((elmXml.get("class") ?? "") + ' $name').trim());
+	}
+
+	public function removeClass(elm: Element, name: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final elmXml: Xml = cast elm;
+		var list = elmXml.get("class").split(" ");
+		list.remove(name);
+		elmXml.set("class", list.join(" "));
+	}
+
+	public function setStyle(elm: Element, name: String, value: Any #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {}
+
+	public function removeStyle(elm: Element, name: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {}
+
+	public function isElement(node: Any): Bool {
+		if (!Std.isOfType(node, Xml)) return false;
+		final nodeXml: Xml = cast node;
+		return nodeXml.nodeType == Element;
+	}
+
+	public function isText(node: Node): Bool {
+		if (!Std.isOfType(node, Xml)) return false;
+		final nodeXml: Xml = cast node;
+		return nodeXml.nodeType == PCData;
+	}
+
+	public function isComment(node: Node): Bool {
+		if (!Std.isOfType(node, Xml)) return false;
+		final nodeXml: Xml = cast node;
+		return nodeXml.nodeType == Comment;
+	}
+
+	public function elementId(elm: Element): Null<String> {
+		final elmXml: Xml = cast elm;
+		return elmXml.get("id");
+	}
+
+	public function attribute(elm: Element, attr: String): Null<String> {
+		final elmXml: Xml = cast elm;
+		return elmXml.get(attr);
+	}
+
+	public function setAttribute(elm: Element, attr: String, value: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final elmXml: Xml = cast elm;
+		elmXml.set(attr, value);
+	}
+
+	public function removeAttribute(elm: Element, attr: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {
+		final elmXml: Xml = cast elm;
+		elmXml.remove(attr);
+	}
+
+	public function setProp(elm: Element, name: String, value: Any #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {}
+
+	public function resetProp(elm: Element, name: String #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {};
+
+	public function elementToNode(elm: Element): Node {
+		return cast elm;
+	}
+
+	public function textToNode(text: Text): Node {
+		return cast text;
+	}
+
+	public function commentToNode(comment: Comment): Node {
+		return cast comment;
+	}
+
+	public function vnodeDataToCreateElementOptions(data: VNodeData): CreateElementOptions {
+		return cast {
+			'is': data.isa
+		};
+	}
+
+	public function isAttribute(sel: String, name: String): Bool {
+		return HtmlAttributes.isValidAttribute(sel, name) || SvgAttributes.isValidAttribute(sel, name);
+	}
+
+	public function addEventListener(elm: Element, event: String, listener: Function #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {}
+
+	public function removeEventListener(elm: Element, event: String, listener: Function #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {}
+
+	public function fallbackComponentVNode(xid: Xid, #if wisdom_debug, ?pos: haxe.PosInfos #end): VNode {
+		return VNode.vnode(xid, 'div', {}, [], null, null);
+	}
+
+	public function didAppendChildren(elm: Element #if wisdom_debug, ?pos: haxe.PosInfos #end): Void {}
+}
+//
+
+class Test implements X {
+  static function main() {
+    var test = new Test();
+    // supposed to print
+    // parsed: ,<div class="my-wisdom-words">Some words of wisdom</div>
+	var elm:String = cast test.container.elm;
+    trace("parsed: ", elm);
+	// TODO when String null is fixed can be a sraight equality check rather then contains
+	if (!StringTools.contains(elm, 'Some words of wisdom</div>')) {
+		throw "failure";
+	}
+  }
+
+  var container: VNode;
+
+  public function new() {
+    var wisdom = new Wisdom([
+        ClassModule.module(),
+        StyleModule.module(),
+        PropsModule.module(),
+        AttributesModule.module(),
+        ListenersModule.module()
+      ],
+      new StaticWisdomBackend()
+    );
+
+    this.container = {
+      xid: "",
+      sel: "",
+      data: {},
+      children: [],
+      elm: cast Xml.createDocument(),
+      text: null,
+      key: null
+    };
+
+    this.container = wisdom.patch(container,
+      '<>
+          <div class="my-wisdom-words">
+              Some words of wisdom
+        </div>
+      '
+    );
+  }
+}

--- a/examples/wisdom/build.hxml
+++ b/examples/wisdom/build.hxml
@@ -1,0 +1,7 @@
+-cp examples/wisdom
+-L hx2go
+-main Test
+-L wisdom
+--custom-target go=output/examples/wisdom
+-w -WIfDisplay
+--cmd go -C output/examples/wisdom/main run .

--- a/source/hx2go/passes/CastClass.hx
+++ b/source/hx2go/passes/CastClass.hx
@@ -63,7 +63,7 @@ class CastClass extends CompilerPass {
                         name: "HxDynamic",
                         moduleName: "HxDynamic",
                         pack: ["go", "haxe"]
-                    }, "toClass", [e, new HxbTypedExpr(TConst(TString(StringConversions.typePathClassInstanceName(cls.path))), TString, null)]);
+                    }, "castClass", [e, new HxbTypedExpr(TConst(TString(StringConversions.typePathClassInstanceName(cls.path))), TString, null)]);
 
                     var name = StringConversions.typePathClassInstanceName(cls.path);
                     var tmp = new HxbVar(-1, 'hx_dyncast_${castId++}', VUser(TVOLocalVariable), 0, [], e.pos, callExpr.t);

--- a/source/hx2go/passes/TypeNormaliserCall.hx
+++ b/source/hx2go/passes/TypeNormaliserCall.hx
@@ -138,6 +138,20 @@ class TypeNormaliserCall extends CompilerPass {
                     declaredParams(callee)
                 );
 
+            // follow the typedef of function types, as they are no longer aliases, see TypeWriter writeTypedef func
+            case TCall({ t: t = TType(_, _), expr: callee }, args) if (TypeHelper.follow(context, t).match(TFun(_, _))):
+                switch TypeHelper.follow(context, t) {
+                    case TFun(params, ret):
+                        norm(
+                            FieldAccessExtern.getExternInfo(context, new HxbTypedExpr(callee, TFun(params, ret), expr.pos)),
+                            args,
+                            params,
+                            expr,
+                            declaredParams(callee)
+                        );
+                    case _:
+                }
+
             case TCall({ expr: TConst(TSuper), t: TInst(tp, _) }, args) | TNew(tp, _, args): {
                 var m = context.resolve(tp);
                 if (m == null) {

--- a/source/hx2go/writers/TypeWriter.hx
+++ b/source/hx2go/writers/TypeWriter.hx
@@ -73,7 +73,11 @@ class TypeWriter extends WriterImpl {
         }
 
         buf.add("");
-        buf.add('type ${StringConversions.typePathTypedefName(t.path)} = ${writeHxbType(t.type)}');
+        // required as otherwise an internal Go compiler error occurs
+        // by an alias forcing an eager underlying resolution returning nil
+        var isFunc = writer.context.normalize(t.type).match(TFun(_, _));
+        var eq = isFunc ? "" : "= ";
+        buf.add('type ${StringConversions.typePathTypedefName(t.path)} ${eq}${writeHxbType(t.type)}');
 
         return buf;
     }


### PR DESCRIPTION
See #174 for more info. For a quick update, many of the previous issues seemed to be fixed from the Array revamp V2 PR being merged in, the first commit avoids a Go compiler panic on eager looking up a type alias generic function, for now we avoid it by changing alias to normal type for only func types.

Currently running into a runtime null panic:
```sh
testbed/Test.hx:165: isElement nodeXml=null nodeType=null
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xc4419b3]

goroutine 1 [running]:
main.(*Hx_Obj_staticwisdombackend).Hx_Field_isElement(0xfcf59e50200?, {0xc6b1540?, 0xfcf59e50180?})
        /Users/o/Documents/GitHub/hx2go-v2/output/testbed/main/Hx_Test.go:730 +0x253
main.(*Hx_Obj_wisdom_wisdom).Hx_Field__patch(0xfcf59d5c870, {0xc6b1540, 0xfcf59e50180}, 0xfcf59e50200)
        /Users/o/Documents/GitHub/hx2go-v2/output/testbed/main/Hx_wisdom_Wisdom.go:1248 +0x130
main.(*Hx_Obj_test).Hx_New(0xfcf59d5c810)
        /Users/o/Documents/GitHub/hx2go-v2/output/testbed/main/Hx_Test.go:1000 +0x422
main.Hx_Obj_test_CreateInstance()
        /Users/o/Documents/GitHub/hx2go-v2/output/testbed/main/Hx_Test.go:955 +0x53
main.Hx_Field_test_main()
        /Users/o/Documents/GitHub/hx2go-v2/output/testbed/main/Hx_Test.go:1027 +0x17
main.main()
        /Users/o/Documents/GitHub/hx2go-v2/output/testbed/main/Main.go:5 +0xf
exit status 2
```