### PR TITLE
HxString null #187

### DIFF
--- a/_std/Reflect.hx
+++ b/_std/Reflect.hx
@@ -25,14 +25,13 @@ class Reflect {
     }
 
     public static function setProperty(o: Dynamic, field: String, value: Dynamic): Void {
-        try HxDynamic.setField(o, field, value) catch(_) {
-            var fn = HxDynamic.getField(o, 'set_${field}');
-            if (fn == null) {
-                throw 'Reflect.setProperty "${o}" does not contain field or setter "${field}"';
-            }
-
-            HxDynamic.call(fn, [value]);
+        var fn = HxDynamic.getField(o, 'set_${field}');
+        if (fn == null) {
+            HxDynamic.setField(o, field, value);
+            return;
         }
+
+        HxDynamic.call(fn, [value]);
     }
 
     public static function callMethod(o: Dynamic, func: haxe.Constraints.Function, args: Array<Dynamic>): Dynamic {
@@ -61,7 +60,13 @@ class Reflect {
         }
 
         if (kind == go.Reflect.struct) {
-            return Type.getInstanceFields(Type.getClass(o));
+            var t = Type.typeof(o);
+            switch t {
+                case TClass(c):
+                    return Type.getInstanceFields(c);
+                default:
+                    return o.staticFields;
+            }
         }
 
         return [];

--- a/_std/Reflect.hx
+++ b/_std/Reflect.hx
@@ -79,6 +79,11 @@ class Reflect {
     }
 
     public static function compare<T>(a: T, b: T): Int {
+        var aIsNull = go.haxe.HxStringNull.dynIsStringNull(a);
+        var bIsNull = go.haxe.HxStringNull.dynIsStringNull(b);
+        if (aIsNull || bIsNull) {
+            return (aIsNull && bIsNull) ? 0 : -1;
+        }
         return try (a == b) ? 0 : (((a : Dynamic) > (b : Dynamic)) ? 1 : -1) catch (_) -1;
     }
 
@@ -108,6 +113,11 @@ class Reflect {
 
             value = value.elem();
             kind = value.kind();
+        }
+
+        // null String is not an object
+        if (kind == go.Reflect.string && go.haxe.HxStringNull.isNull(value.string())) {
+            return false;
         }
 
         var type = value.type();

--- a/_std/go/haxe/HxClass.hx
+++ b/_std/go/haxe/HxClass.hx
@@ -13,8 +13,9 @@ class HxClass {
     public var createInstance: (Array<Dynamic>) -> Dynamic;
     public var createEmptyInstance: () -> Dynamic;
     public var __meta__: Dynamic;
+    public var getStaticFieldPtr: (String) -> Dynamic;
 
-    public function new(name: String, staticFields: Array<String>, instanceFields: Array<String>, superClass: HxClass, interfaces: Array<HxClass>, createInstance: (Array<Dynamic>) -> Dynamic, createEmptyInstance: () -> Dynamic, __meta__: Dynamic) {
+    public function new(name: String, staticFields: Array<String>, instanceFields: Array<String>, superClass: HxClass, interfaces: Array<HxClass>, createInstance: (Array<Dynamic>) -> Dynamic, createEmptyInstance: () -> Dynamic, __meta__: Dynamic, getStaticFieldPtr: (String) -> Dynamic) {
         this.name = name;
         this.staticFields = staticFields;
         this.instanceFields = instanceFields;
@@ -23,6 +24,7 @@ class HxClass {
         this.createInstance = createInstance;
         this.createEmptyInstance = createEmptyInstance;
         this.__meta__ = __meta__;
+        this.getStaticFieldPtr = getStaticFieldPtr;
         _registry.set(name, this);
     }
 

--- a/_std/go/haxe/HxDynamic.hx
+++ b/_std/go/haxe/HxDynamic.hx
@@ -169,6 +169,10 @@ class HxDynamic {
             return v.isNil();
         }
 
+        if (k == Reflect.string) {
+            return HxStringNull.isNull(v.string());
+        }
+
         return false;
     }
 

--- a/_std/go/haxe/HxDynamic.hx
+++ b/_std/go/haxe/HxDynamic.hx
@@ -9,6 +9,7 @@ import go.Syntax;
 import go.Fmt;
 import go.Pointer;
 import go.unsafe.Pointer as UnsafePointer;
+import go.haxe.HxClass;
 
 // HxDynamic implements Dynamic runtime manipulation required by Haxe
 // using go.reflect.Reflect and naming from http://haxedev.wikidot.com/article:operator-overloading
@@ -685,6 +686,31 @@ class HxDynamic {
         return getFieldFrom(dyn, fieldName, true);
     }
 
+    static function tryHxClass(dyn: Dynamic): HxClass {
+        var cls: HxClass = null;
+        var ok: Bool = false;
+        Syntax.code("{0}, {1} = {2}.(*Hx_Obj_go_haxe_hxclass)", cls, ok, dyn);
+        return ok ? cls : null;
+    }
+
+    static function hxClassStaticValue(cls: HxClass, fieldName: String): Value {
+        if (cls.getStaticFieldPtr == null) {
+            return Null;
+        }
+
+        var ptr: Dynamic = cls.getStaticFieldPtr(fieldName);
+        if (isNull(ptr)) {
+            return Null;
+        }
+
+        var pv = ensureConcreteValue(ptr);
+        if (pv.kind() == Reflect.ptr) {
+            return pv.elem();
+        }
+
+        return pv;
+    }
+
     static function getFieldFrom(dyn: Dynamic, fieldName: String, hop: Bool): Dynamic {
         Syntax.code("
             switch m := {0}.(type) {
@@ -697,6 +723,20 @@ class HxDynamic {
 
         if (isNull(dyn)) {
             throw "runtime.HxDynamic.field null field access: " + fieldName;
+        }
+
+        var hxCls = tryHxClass(dyn);
+        if (hxCls != null) {
+            var sv = hxClassStaticValue(hxCls, fieldName);
+            if (sv.isValid()) {
+                sv = unwrapNullable(sv);
+                if (!sv.isValid()) {
+                    return null;
+                }
+
+                return sv.canInterface() ? sv._interface() : null;
+            }
+            // fall through
         }
 
         var arr = tryDynamicArray(dyn);
@@ -811,6 +851,20 @@ class HxDynamic {
 
     // write field access on dynamic (class, anon, etc)
     public static function setField(dyn: Dynamic, fieldName: String, v: Dynamic): Dynamic {
+        var hxCls = tryHxClass(dyn);
+        if (hxCls != null) {
+            var sv = hxClassStaticValue(hxCls, fieldName);
+            if (sv.isValid()) {
+                if (!sv.canSet()) {
+                    throw 'runtime.HxDynamic.setField cannot set static "$fieldName" on "${hxCls.name}"';
+                }
+
+                sv.set(valueToAssign(v, sv.type()));
+                return v;
+            }
+            // fall through
+        }
+
         var value = ensureValue(dyn);
         var kind = value.kind();
 

--- a/_std/go/haxe/HxStringNull.hx
+++ b/_std/go/haxe/HxStringNull.hx
@@ -1,0 +1,25 @@
+package go.haxe;
+
+import go.Reflect;
+import go.reflect.Value;
+import go.Syntax;
+import go.haxe.HxDynamic;
+
+class HxStringNull {
+    public static function isNull(s: String): Bool {
+        return Syntax.code("isStringNull({0})", s);
+    }
+
+    public static function dynIsStringNull(d: Dynamic): Bool {
+        if (Syntax.code("{0} == nil", d)) {
+            return false;
+        }
+
+        var v: Value = HxDynamic.ensureConcreteValue(d);
+        if (!v.isValid() || v.kind() != Reflect.string) {
+            return false;
+        }
+
+        return Syntax.code("isStringNull({0})", v.string());
+    }
+}

--- a/runtime/String.go
+++ b/runtime/String.go
@@ -5,10 +5,13 @@ import (
 	"unsafe"
 )
 
-var ASCIInullStr = "null\u0000"
-var HxStringNull, _ = strings.CutSuffix("null"+ASCIInullStr, ASCIInullStr)
+var ASCIInullStr = "\u0000"
+var HxStringNull, _ = strings.CutSuffix("《null》"+ASCIInullStr, ASCIInullStr)
 
 func isStringNull(s string) bool {
+	if len(s) != len(HxStringNull) {
+		return false
+	}
 	return unsafe.StringData(s) == unsafe.StringData(HxStringNull)
 }
 

--- a/runtime/String.go
+++ b/runtime/String.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"unsafe"
+)
+
+var ASCIInullStr = "null\u0000"
+var HxStringNull, _ = strings.CutSuffix("null"+ASCIInullStr, ASCIInullStr)
+
+func isStringNull(s string) bool {
+	return unsafe.StringData(s) == unsafe.StringData(HxStringNull)
+}
+
+func HxStringCompare(a string, b string) bool {
+	if a == b {
+		ua := isStringNull(a)
+		ub := isStringNull(b)
+		if ua || ub {
+			return ua && ub
+		}
+		return true
+	} else {
+		return false
+	}
+}

--- a/runtime/String.go
+++ b/runtime/String.go
@@ -6,7 +6,7 @@ import (
 )
 
 var ASCIInullStr = "\u0000"
-var HxStringNull, _ = strings.CutSuffix("《null》"+ASCIInullStr, ASCIInullStr)
+var HxStringNull, _ = strings.CutSuffix(ASCIInullStr+"null"+ASCIInullStr, ASCIInullStr)
 
 func isStringNull(s string) bool {
 	if len(s) != len(HxStringNull) {

--- a/runtime/Util.go
+++ b/runtime/Util.go
@@ -48,6 +48,9 @@ func HxConvert[T any](from any) T {
 	}
 
 	if from == nil {
+		if tt.Kind() == reflect.String {
+			return reflect.ValueOf(HxStringNull).Convert(tt).Interface().(T)
+		}
 		return HxDefault[T]()
 	}
 

--- a/source/hx2go/writers/ClassWriter.hx
+++ b/source/hx2go/writers/ClassWriter.hx
@@ -19,7 +19,7 @@ import hx2go.util.ExprHelper;
 
 class ClassWriter extends WriterImpl {
 
-    function classMeta(cls: HxbClass): String {
+    public function classMeta(cls: HxbClass): String {
         var fields: Array<{ name: String, meta: Array<hxb.Ast.HxbMetaEntry> }> =
             cls.fields.map(f -> { name: f.name, meta: f.meta });
         if (cls.constructor != null) {
@@ -60,6 +60,8 @@ class ClassWriter extends WriterImpl {
             buf.add('panic("Cannot dynamically create instance of extern class")', 2);
             buf.add('},', 1);
             buf.add('nil,', 1);
+            buf.addBuffer(writeStaticFieldPtrClosure(cls), 1, false);
+            buf.addInline(',\n');
             buf.add(')');
 
             return buf;
@@ -370,6 +372,8 @@ class ClassWriter extends WriterImpl {
             buf.add('return ${StringConversions.typePathClassInstanceName(cls.path)}_CreateEmptyInstance()', 2);
             buf.add('},', 1);
             buf.add('${classMeta(cls)},', 1);
+            buf.addBuffer(writeStaticFieldPtrClosure(cls), 1, false);
+            buf.addInline(',\n');
             buf.add(')');
 
             buf.add('');
@@ -400,6 +404,8 @@ class ClassWriter extends WriterImpl {
             buf.add('return nil', 2);
             buf.add('},', 1);
             buf.add('${classMeta(cls)},', 1);
+            buf.addBuffer(writeStaticFieldPtrClosure(cls), 1, false);
+            buf.addInline(',\n');
             buf.add(')');
         }
 
@@ -411,6 +417,49 @@ class ClassWriter extends WriterImpl {
 
             buf.addBuffer(res);
         }
+
+        return buf;
+    }
+
+    public function writeStaticFieldPtrClosure(cls: HxbClass): OutputBuffer {
+        var buf = new OutputBuffer();
+        var isExternCls = cls.flags & HxbClassFlag.CExtern != 0;
+
+        buf.addInline('func (name string) any {');
+
+        if (!isExternCls) {
+            var cases: Array<{ name: String, expr: String }> = [];
+
+            for (f in cls.statics) {
+                if (f.flags & HxbClassFieldFlag.CfExtern != 0) continue;
+                if (f.flags & HxbClassFieldFlag.CfGeneric != 0) continue;
+
+                var sfName = StringConversions.typePathStaticFieldName(f.name, cls.path);
+
+                switch f.kind {
+                    case KVar(_, _):
+                        if (!shouldGenVar(f)) continue;
+                        // package var exists -> return its address (settable)
+                        cases.push({ name: f.name, expr: '&$sfName' });
+                    case KMethod(_):
+                        if (f.expr == null) continue; // abstract, no func emitted
+                        // return the func value directly
+                        cases.push({ name: f.name, expr: sfName });
+                }
+            }
+
+            if (cases.length > 0) {
+                buf.add('switch name {', 1);
+                for (c in cases) {
+                    buf.add('case "${c.name}":', 1);
+                    buf.add('return ${c.expr}', 2);
+                }
+                buf.add('}', 1);
+            }
+        }
+
+        buf.add('return nil', 1);
+        buf.addInline('}');
 
         return buf;
     }

--- a/source/hx2go/writers/ExprWriter.hx
+++ b/source/hx2go/writers/ExprWriter.hx
@@ -667,8 +667,16 @@ class ExprWriter extends WriterImpl {
     public function writeVarDecl(expr: HxbTypedExpr, v: HxbVar, vexpr: HxbTypedExpr): OutputBuffer {
         var buf = new OutputBuffer();
 
-        var hasInit = vexpr != null
-            && !vexpr.expr.match(TConst(TNull) | TCast({ expr: TConst(TNull) }, _));
+        var isNullInit = vexpr != null
+            && vexpr.expr.match(TConst(TNull) | TCast({ expr: TConst(TNull) }, _));
+        var isStringType = v.type != null && switch TypeHelper.follow(writer.context, v.type, false) {
+            case TString
+               | TInst({ name: "String", pack: [] }, _)
+               | TAbstract({ name: "String", pack: [] }, _): true;
+            case _: false;
+        }
+
+        var hasInit = vexpr != null && (!isNullInit || isStringType);
 
         buf.addInline('var ${v.name} ');
         buf.addBufferInline(writer.types.writeHxbType(v.type));
@@ -678,7 +686,11 @@ class ExprWriter extends WriterImpl {
 
         if (hasInit) {
             buf.addInline('\n${v.name} = ');
-            buf.addBufferInline(writeExpr(vexpr));
+            if (isNullInit && isStringType) {
+                buf.addInline("HxStringNull");
+            } else {
+                buf.addBufferInline(writeExpr(vexpr));
+            }
         }
 
         return buf;
@@ -786,7 +798,7 @@ class ExprWriter extends WriterImpl {
             case TNull: switch TypeHelper.follow(writer.context, expr.t, false) {
                 case TString
                    | TInst({ name: "String", pack: [] }, _)
-                   | TAbstract({ name: "String", pack: [] }, _): "``";
+                   | TAbstract({ name: "String", pack: [] }, _): "HxStringNull";
                 case _: "nil";
             }
             case TThis: "this";

--- a/source/hx2go/writers/TypeWriter.hx
+++ b/source/hx2go/writers/TypeWriter.hx
@@ -55,6 +55,7 @@ class TypeWriter extends WriterImpl {
         buf.add('return nil', 2);
         buf.add('},', 1);
         buf.add('${abstractMeta(a)},', 1);
+        buf.add('func (name string) any { return nil },', 1);
         buf.add(')');
 
         return buf;

--- a/tests/unit/ReflectStaticFieldProp.hx
+++ b/tests/unit/ReflectStaticFieldProp.hx
@@ -26,11 +26,6 @@ function main() {
 
 }
 
-
-function eq(a, b) {
-	assert(a, b);
-}
-
 class ClassWithProp {
 	public function new() {}
 	public static var STAT_X(default, set) : Int;

--- a/tests/unit/ReflectStaticFieldProp.hx
+++ b/tests/unit/ReflectStaticFieldProp.hx
@@ -1,0 +1,48 @@
+package unit;
+function main() {
+	var c = new ClassWithProp();
+	// instance fields
+	assert(Reflect.fields(c).length == 0);
+	// static var
+	// look up
+	var cl = Type.resolveClass("ClassWithProp");
+	assert(Reflect.field(cl, "STAT_X") == 6);
+	Reflect.setField(cl, "STAT_X", 11);
+	assert(Reflect.field(cl, "STAT_X") == 11);
+	assert(Reflect.fields(cl).length > 0);
+	// access directly
+	assert(Reflect.field(ClassWithProp, "STAT_Y") == 10);
+	assert(Reflect.hasField(ClassWithProp, "STAT_Y"));
+	Reflect.setField(ClassWithProp, "STAT_Y", 11);
+	assert(Reflect.field(ClassWithProp, "STAT_Y") == 11);
+	// static prop
+	assert(ClassWithProp.STAT_X == 11);
+
+	Reflect.setProperty(ClassWithProp, "STAT_X", 8);
+
+	assert(ClassWithProp.STAT_X == 16);
+	assert(Reflect.getProperty(ClassWithProp, "STAT_X") == 16);
+
+
+}
+
+
+function eq(a, b) {
+	assert(a, b);
+}
+
+class ClassWithProp {
+	public function new() {}
+	public static var STAT_X(default, set) : Int;
+	public static var STAT_Y:Int = 10;
+
+	static function set_STAT_X(v) {
+		STAT_X = v * 2;
+		return v;
+	}
+
+	static function __init__() {
+		STAT_X = 3;
+	}
+
+}

--- a/tests/unit/ReflectStaticFieldProp.hx
+++ b/tests/unit/ReflectStaticFieldProp.hx
@@ -5,7 +5,7 @@ function main() {
 	assert(Reflect.fields(c).length == 0);
 	// static var
 	// look up
-	var cl = Type.resolveClass("ClassWithProp");
+	var cl = Type.resolveClass("unit.ClassWithProp");
 	assert(Reflect.field(cl, "STAT_X") == 6);
 	Reflect.setField(cl, "STAT_X", 11);
 	assert(Reflect.field(cl, "STAT_X") == 11);

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -17,8 +17,6 @@ function main() {
 
     assert((nul == "null") == false);    // String Null should be different from the string "null"
 
-    assert((("abc"+nul) == "abc\u0000null") == true); 
-
     assert(empty.length == 0);
 
     // null prints "null", "" prints ""

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -1,5 +1,6 @@
 package unit;
 
+
 function main() {
     var empty:String = "";
     var nul:String = null;
@@ -13,6 +14,8 @@ function main() {
     assert((nul == nul2) == true);       // two nulls are equal
     assert((empty == nul) == false);     // "" is not null, both operand orders
     assert((nul == empty) == false);
+
+    assert((nul == "null") == false);    // String Null should be different from the string "null"
 
     assert(empty.length == 0);
 

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -17,6 +17,8 @@ function main() {
 
     assert((nul == "null") == false);    // String Null should be different from the string "null"
 
+    assert((("abc"+nul) == "abc\u0000null") == true); 
+
     assert(empty.length == 0);
 
     // null prints "null", "" prints ""

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -1,0 +1,43 @@
+package unit;
+
+function main() {
+    var empty:String = "";
+    var nul:String = null;
+    var nul2:String = null;
+
+    // "" and null are distinct
+    assert((empty == null) == false);
+    assert((nul == null) == true);
+    assert((empty == "") == true);
+    assert((nul == "") == false);        // key case: null String is NOT ""
+    assert((nul == nul2) == true);       // two nulls are equal
+    assert((empty == nul) == false);     // "" is not null, both operand orders
+    assert((nul == empty) == false);
+
+    assert(empty.length == 0);
+
+    // null prints "null", "" prints ""
+    assert(Std.string(empty) == "");
+    assert(Std.string(nul) == "null");
+
+    // Reflect.isObject: "" is a real string (object), null is not
+    assert(Reflect.isObject(empty) == true);
+    assert(Reflect.isObject(nul) == false);
+
+    // Reflect.compare
+    assert(Reflect.compare(empty, empty) == 0);   // equal empties
+    assert(Reflect.compare(nul, nul2) == 0);      // both null -> 0
+    assert(Reflect.compare(nul, empty) == -1);    // one null (a) -> -1
+    assert(Reflect.compare(empty, nul) == -1);    // one null (b) -> -1
+    assert(Reflect.compare(empty, "a") < 0);      // "" < "a", normal ordering
+
+    // Dynamic strings behave identically
+    var dEmpty:Dynamic = empty;
+    var dNul:Dynamic = nul;
+    assert((dEmpty == null) == false);
+    assert((dNul == null) == true);
+    assert(Std.string(dEmpty) == "");
+    assert(Std.string(dNul) == "null");
+    assert(Reflect.compare(dNul, dEmpty) == -1);
+    assert(Reflect.compare(dEmpty, dEmpty) == 0);
+}


### PR DESCRIPTION
This implements HxStringNull constant, thanks to the work of @elliott5 

Here is some test code to demonstrate what we are going after:
```haxe
var empty:String = "";
    var nul:String = null;
    var nul2:String = null;

    // "" and null are distinct
    assert((empty == null) == false);
    assert((nul == null) == true);
    assert((empty == "") == true);
    assert((nul == "") == false);        // key case: null String is NOT ""
    assert((nul == nul2) == true);       // two nulls are equal
    assert((empty == nul) == false);     // "" is not null, both operand orders
    assert((nul == empty) == false);

    assert(empty.length == 0);

    // null prints "null", "" prints ""
    assert(Std.string(empty) == "");
    assert(Std.string(nul) == "null");

    // Reflect.isObject: "" is a real string (object), null is not
    assert(Reflect.isObject(empty) == true);
    assert(Reflect.isObject(nul) == false);

    // Reflect.compare
    assert(Reflect.compare(empty, empty) == 0);   // equal empties
    assert(Reflect.compare(nul, nul2) == 0);      // both null -> 0
    assert(Reflect.compare(nul, empty) == -1);    // one null (a) -> -1
    assert(Reflect.compare(empty, nul) == -1);    // one null (b) -> -1
    assert(Reflect.compare(empty, "a") < 0);      // "" < "a", normal ordering

    // Dynamic strings behave identically
    var dEmpty:Dynamic = empty;
    var dNul:Dynamic = nul;
    assert((dEmpty == null) == false);
    assert((dNul == null) == true);
    assert(Std.string(dEmpty) == "");
    assert(Std.string(dNul) == "null");
    assert(Reflect.compare(dNul, dEmpty) == -1);
    assert(Reflect.compare(dEmpty, dEmpty) == 0);
```