### PR TITLE
Alter HxStringNull to be a Go const rather than a Go var

### DIFF
--- a/runtime/String.go
+++ b/runtime/String.go
@@ -1,18 +1,13 @@
 package main
 
-import (
-	"strings"
-	"unsafe"
-)
-
-var ASCIInullStr = "\u0000"
-var HxStringNull, _ = strings.CutSuffix(ASCIInullStr+"null"+ASCIInullStr, ASCIInullStr)
+// HxStringNull is the Haxe null string representation.
+// It is a constant so that it can be safely used during the Go initialization process.
+// Its value is "null" with a null character prefix, which displays correctly because the null character is ignored.
+// This unusual value is used to represent the Haxe null string in Go, as Go does not have a direct equivalent for Haxe's null string.
+const HxStringNull = "\u0000null"
 
 func isStringNull(s string) bool {
-	if len(s) != len(HxStringNull) {
-		return false
-	}
-	return unsafe.StringData(s) == unsafe.StringData(HxStringNull)
+	return s == HxStringNull
 }
 
 func HxStringCompare(a string, b string) bool {

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -16,7 +16,7 @@ function main() {
     assert((nul == empty) == false);
 
     assert(nul != "null");               // String Null should be different from the string "null"
-    assert(nul == "\x00null");           // String Null should be equal to the string "\x00null"
+    assert(nul == "\u0000null");         // String Null should be equal to the string "\u0000null"
 
     assert(empty.length == 0);
 

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -16,7 +16,6 @@ function main() {
     assert((nul == empty) == false);
 
     assert(nul != "null");               // String Null should be different from the string "null"
-    assert(nul == "\u0000null");         // String Null should be equal to the string "\u0000null"
 
     assert(empty.length == 0);
 

--- a/tests/unit/StringNullEmpty.hx
+++ b/tests/unit/StringNullEmpty.hx
@@ -15,7 +15,8 @@ function main() {
     assert((empty == nul) == false);     // "" is not null, both operand orders
     assert((nul == empty) == false);
 
-    assert((nul == "null") == false);    // String Null should be different from the string "null"
+    assert(nul != "null");               // String Null should be different from the string "null"
+    assert(nul == "\x00null");           // String Null should be equal to the string "\x00null"
 
     assert(empty.length == 0);
 


### PR DESCRIPTION
Making `HxStringNull` a Go `const` means can safely be used during the initialization phase.

By contrast a Go `var` (as `HxStringNull` was) is set to its initial value at some point during the initialization phase.
If another variable were to use `HxStringNull` earlier in the initialization phase, before `HxStringNull` had been initialized, an incorrect value would be used. This PR removes that possibility.